### PR TITLE
PULL_REQUEST_TEMPLATE.md: fix typo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ _You can erase any parts of this template not applicable to your Pull Request._
 
 - [ ] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
-+ [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
+- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
 - [ ] Does your submission pass
 `brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
 - [ ] Have you built your formula locally prior to submission with `brew install <formula>`?


### PR DESCRIPTION
The pull request template used a "+" instead of a "-" in one instance.
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
