### PR TITLE
wayland: depends on libxml2

### DIFF
--- a/wayland.rb
+++ b/wayland.rb
@@ -15,6 +15,7 @@ class Wayland < Formula
   depends_on "expat"
   depends_on "libffi"
   depends_on "autoconf" if build.head?
+  depends_on "libxml2"
 
   def install
     args = %W[


### PR DESCRIPTION
``` bash
$ patchelf --print-needed ~/.linuxbrew/opt/wayland/bin/wayland-scanner 
libexpat.so.1
libxml2.so.2
libc.so.6
```
