### PR TITLE
The sha256 for README.md seems to have changed.

### DIFF
--- a/xorg-protocols.rb
+++ b/xorg-protocols.rb
@@ -3,7 +3,7 @@ class XorgProtocols < Formula
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
   url      "https://raw.githubusercontent.com/Linuxbrew/homebrew-xorg/master/README.md"
   version  "latest"
-  sha256   "846477dd316964fe52e9f73c3752d3c0383f7099046dd06ddfda92c2f9baad5d"
+  sha256   "7d5cca1b4bdc2a3aefe2ef7fedf919ea8fe4f907493d5d31661c5f8fa81a3161"
   # tag "linuxbrew"
 
   bottle do


### PR DESCRIPTION
Installing xorg-protocols as a prereq to installing R failed (CentOS 7, `HOMEBREW_BUILD_FROM_SOURCE=1`).

```
[throgg@builder apps]$ brew install r
==> Installing r from homebrew/science
==> Installing dependencies for homebrew/science/r: xorg-protocols, libxau, xcb-proto, libxdmcp, gettext, homebrew/dupes/m4, bison, \
flex, doxygen
==> Installing homebrew/science/r dependency: xorg-protocols
==> Downloading https://raw.githubusercontent.com/Linuxbrew/homebrew-xorg/master/README.md
Already downloaded: /home/throgg/.cache/Homebrew/xorg-protocols-latest.md
Error: SHA256 mismatch
Expected: 846477dd316964fe52e9f73c3752d3c0383f7099046dd06ddfda92c2f9baad5d
Actual: 7d5cca1b4bdc2a3aefe2ef7fedf919ea8fe4f907493d5d31661c5f8fa81a3161
Archive: /home/throgg/.cache/Homebrew/xorg-protocols-latest.md
To retry an incomplete download, remove the file above.
[throgg@builder apps]$
```

Replacing the Expected value of the sha256 in the formula with the actual allowed the build to proceed.

I grabbed the README.md using curl, verified that it's sha256 was what the install step found, and scanned the file by eye.  It seems ok.
