### PR TITLE
.travis.yml: Set HOMEBREW_DEVELOPER on Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ before_install:
 
 install:
   - PATH=$PWD/bin:$PATH
-  - export HOMEBREW_DEVELOPER="1"
 
 script:
   - docker run
     -w /home/linuxbrew/.linuxbrew/Library/Taps/linuxbrew/homebrew-xorg
+    -e "HOMEBREW_DEVELOPER=1"
     --env-file /tmp/travis.env
     -t
     linuxbrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

Travis CI has not been working correctly for the past couple of weeks. It [keeps failing](https://travis-ci.org/Linuxbrew/homebrew-xorg/builds/143788377#L222) with the message `Error: Unknown command: test-bot`.

Fix by setting the `HOMEBREW_DEVELOPER` environment variable inside Docker rather than inside Travis itself.
