### PR TITLE
pciutils: add a post_install phase that updates device definitions

### DIFF
--- a/pciutils.rb
+++ b/pciutils.rb
@@ -20,6 +20,10 @@ class Pciutils < Formula
     system "make", *args, "install", "install-lib"
   end
 
+  def post_install
+    system "#{sbin}/update-pciids"
+  end
+
   test do
     output = shell_output("#{sbin}/lspci --version").chomp
     assert_match output, "lspci version #{version}"


### PR DESCRIPTION
# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] Does your submission pass
  `brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

Add a post_install phase that updates device definitions.
