### PR TITLE
mkfontscale: add missing xproto dependency

### DIFF
--- a/mkfontscale.rb
+++ b/mkfontscale.rb
@@ -13,6 +13,7 @@ class Mkfontscale < Formula
   depends_on "libfontenc"
   depends_on "freetype"
   depends_on "bzip2" if build.with?("bzip2")
+  depends_on "xproto" => :build
 
   def install
     args = %W[


### PR DESCRIPTION
# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] Does your submission pass
  `brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

When building `mkfontscale` on Travis, an error is returned stating that it is missing a dependency on `xproto`. On a regular workstation, `xproto` is engaged as a dependency of `libfontenc`. 
_TODO_: figure out why :)

WIP
