### PR TITLE
libdrm: add missing automake build-time dependency

### DIFF
--- a/libdrm.rb
+++ b/libdrm.rb
@@ -11,6 +11,7 @@ class Libdrm < Formula
   depends_on "pkg-config" => :build
   depends_on "util-macros" => :build
   depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "libpciaccess" => :build
 


### PR DESCRIPTION
- [x] Ran `brew update` and retried your prior step?
- [x] Ran `brew doctor`, fixed as many issues as possible and retried your prior step?

---

see #188 
Travis can not find `aclocal` when building bottle for `libdrm`.
`aclocal` is provided by `automake`
