### PR TITLE
libpthread-stubs 0.3

### DIFF
--- a/libdrm.rb
+++ b/libdrm.rb
@@ -19,6 +19,7 @@ class Libdrm < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "libpciaccess" => :build
+  depends_on "libpthread-stubs" => :build
 
   def install
     args = %W[
@@ -32,9 +33,6 @@ class Libdrm < Formula
 
     # Be explicit about the configure flags
     args << "--enable-static=#{build.with?("static") ? "yes" : "no"}"
-
-    ## Get rid of dependency on libpthread-stubs
-    inreplace "configure.ac", /PKG_CHECK_MODULES\(PTHREADSTUBS\, pthread-stubs\)/, ""
 
     ENV["ACLOCAL"] = "aclocal -I #{HOMEBREW_PREFIX}/share/aclocal"
     system "autoreconf", "-fiv"

--- a/libpthread-stubs.rb
+++ b/libpthread-stubs.rb
@@ -1,0 +1,18 @@
+class LibpthreadStubs < Formula
+  desc "X.Org Libraries: libpthread-stubs"
+  homepage "http://www.x.org/"
+  url "https://xcb.freedesktop.org/dist/libpthread-stubs-0.3.tar.bz2"
+  sha256 "35b6d54e3cc6f3ba28061da81af64b9a92b7b757319098172488a660e3d87299"
+  # tag "linuxbrew"
+
+  depends_on "pkg-config"  => :build
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    assert File.exist? "#{lib}/pkgconfig/pthread-stubs.pc"
+  end
+end

--- a/libxcb.rb
+++ b/libxcb.rb
@@ -14,13 +14,14 @@ class Libxcb < Formula
   option "with-static", "Build static libraries (not recommended)"
   option "with-docs",   "Generate API documentation"
 
-  depends_on "pkg-config"  => :build
+  depends_on "pkg-config" => :build
   depends_on "libxau"
-  depends_on "xcb-proto"   => :build
-  depends_on "libxdmcp"    => :recommended
+  depends_on "xcb-proto" => :build
+  depends_on "libpthread-stubs" => :build
+  depends_on "libxdmcp" => :recommended
 
   depends_on "doxygen" => :build if !build.with?("docs")
-  depends_on "check"   => :build if build.with?("test")
+  depends_on "check" => :build if build.with?("test")
   depends_on "libxslt" => [:build, :optional]
 
   def install
@@ -37,9 +38,6 @@ class Libxcb < Formula
     args << "--enable-static=#{build.with?("static") ? "yes" : "no"}"
     args << "--enable-devel-docs=#{build.with?("docs") ? "yes" : "no"}"
     args << "--with-doxygen=#{build.with?("docs") ? "yes" : "no"}"
-
-    ## Get rid of dependency on libpthread-stubs
-    inreplace "configure", /pthread-stubs/, ""
 
     system "./configure", *args
     system "make"

--- a/libxcb.rb
+++ b/libxcb.rb
@@ -1,7 +1,7 @@
 class Libxcb < Formula
   desc "An interface to the X Window System protocol, which replaces the current Xlib interface"
-  homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://xcb.freedesktop.org/dist/libxcb-1.11.1.tar.bz2"
+  homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
+  url "https://xcb.freedesktop.org/dist/libxcb-1.11.1.tar.bz2"
   sha256 "b720fd6c7d200e5371affdb3f049cc8f88cff9aed942ff1b824d95eedbf69d30"
   # tag "linuxbrew"
 
@@ -20,7 +20,7 @@ class Libxcb < Formula
   depends_on "libpthread-stubs" => :build
   depends_on "libxdmcp" => :recommended
 
-  depends_on "doxygen" => :build if !build.with?("docs")
+  depends_on "doxygen" => :build if build.without?("docs")
   depends_on "check" => :build if build.with?("test")
   depends_on "libxslt" => [:build, :optional]
 


### PR DESCRIPTION
This PR provides libpthread-stubs 0.3.

There are three packages depend on this right now: libdrm, libxcb, mesa (#168). The current solution is [patching the code to skip checking for `libpthread-stubs`](https://github.com/Linuxbrew/homebrew-xorg/search?utf8=✓&q=libpthread-stubs). It took me a while to figure it out. So, I think including this package will reduce the future confusion for other contributors.

I understand that this package effectively does nothing on Linux, but I don't see any side effect having it. Plus, contributors can save some time on patching files.

---
## The _only_ file provided by this formula:
#### $prefix/lib/pkgconfig/pthread-stubs.pc

```
prefix=/home/linuxbrew/.linuxbrew/libpthread-stubs/0.3
exec_prefix=${prefix}
libdir=${exec_prefix}/lib

Name: pthread stubs
Description: Stubs missing from libc for standard pthread functions
Version: 0.3
Libs:
```
