### PR TITLE
libxcb: fix dependency on doxygen

### DIFF
--- a/libxcb.rb
+++ b/libxcb.rb
@@ -12,7 +12,7 @@ class Libxcb < Formula
 
   option "without-test", "Skip compile-time tests"
   option "with-static", "Build static libraries (not recommended)"
-  option "with-docs",   "Generate API documentation"
+  option "with-docs", "Generate API documentation"
 
   depends_on "pkg-config" => :build
   depends_on "libxau"
@@ -20,8 +20,8 @@ class Libxcb < Formula
   depends_on "libpthread-stubs" => :build
   depends_on "libxdmcp" => :recommended
 
-  depends_on "doxygen" => :build if build.without?("docs")
-  depends_on "check" => :build if build.with?("test")
+  depends_on "doxygen" => :build if build.with? "docs"
+  depends_on "check" => :build if build.with? "test"
   depends_on "libxslt" => [:build, :optional]
 
   def install
@@ -41,7 +41,7 @@ class Libxcb < Formula
 
     system "./configure", *args
     system "make"
-    system "make", "check" if build.with?("test")
+    system "make", "check" if build.with? "test"
     system "make", "install"
   end
 end


### PR DESCRIPTION
This PR fixes a typo.

In #193, I fixed the audit error `Don't negate 'build.without?': use 'build.with?'` by reversing the syntax without paying attention to the actual logic. I looked at it again and noticed that the extra `!` in the original version was actually a typo, which makes that the package depends on doxygen only when docs is _not_ selected...
