### PR TITLE
libxvmc: audit fixes

### DIFF
--- a/libxvmc.rb
+++ b/libxvmc.rb
@@ -12,13 +12,13 @@ class Libxvmc < Formula
   option "without-test", "Skip compile-time tests"
   option "with-static", "Build static libraries (not recommended)"
 
-  depends_on "pkg-config" =>  :build
+  depends_on "pkg-config" => :build
 
   depends_on "libx11"
   depends_on "libxext"
   depends_on "libxv"
-  depends_on "xextproto"  =>  :build
-  depends_on "videoproto" =>  :build
+  depends_on "xextproto" => :build
+  depends_on "videoproto" => :build
 
   def install
     args = %W[
@@ -28,7 +28,7 @@ class Libxvmc < Formula
       --disable-dependency-tracking
       --disable-silent-rules
     ]
-    args << "--disable-static" if !build.with?("static")
+    args << "--disable-static" if build.without?("static")
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
# Contributing to homebrew-xorg:
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Does your submission pass
  `brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Formula doesn't have a test, so it fails the strict audit, but it's closer to passing now.
