### PR TITLE
libxft: Depends on libxrender

### DIFF
--- a/libxft.rb
+++ b/libxft.rb
@@ -15,13 +15,12 @@ class Libxft < Formula
   option "with-brewed-bzip2", "Use brewed bzip2"
   option "with-brewed-zlib", "Use brewed zlib"
 
-  depends_on "pkg-config" =>  :build
-  depends_on "fontconfig" =>  :build
+  depends_on "pkg-config" => :build
 
-  depends_on "libxrender" =>  :build
-  depends_on "libx11"
-  depends_on "bzip2"      if build.with?("brewed-bzip2")
-  depends_on "zlib"       if build.with?("brewed-zlib")
+  depends_on "fontconfig"
+  depends_on "libxrender"
+  depends_on "bzip2" if build.with?("brewed-bzip2")
+  depends_on "zlib" if build.with?("brewed-zlib")
 
   def install
     args = %W[
@@ -31,7 +30,7 @@ class Libxft < Formula
       --disable-dependency-tracking
       --disable-silent-rules
     ]
-    args << "--disable-static" if !build.with?("static")
+    args << "--disable-static" if build.without?("static")
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
# Contributing to homebrew-xorg:
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

No test, so still fails a strict audit.

This is me finally getting around to one of the formulae mentioned on #84.

```bash
/home/linuxbrew/.linuxbrew/Library/Taps/linuxbrew/homebrew-xorg$ patchelf --print-needed /home/linuxbrew/.linuxbrew/opt/libxft/lib/libXft.so
libfontconfig.so.1
libfreetype.so.6
libXrender.so.1
libX11.so.6
libc.so.6
```