### PR TITLE
xors-protocols: Fix SHA

### DIFF
--- a/xorg-protocols.rb
+++ b/xorg-protocols.rb
@@ -3,7 +3,7 @@ class XorgProtocols < Formula
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
   url      "https://raw.githubusercontent.com/Linuxbrew/homebrew-xorg/master/README.md"
   version  "latest"
-  sha256   "7d5cca1b4bdc2a3aefe2ef7fedf919ea8fe4f907493d5d31661c5f8fa81a3161"
+  sha256   "76b4fd623d6b10d816069aedcffc411e2c9abc607533adf3fa810d7904b5f9d1"
   # tag "linuxbrew"
 
   bottle :unneeded


### PR DESCRIPTION
Needed for 317ef5e60c62298a28f08bb44ca6a09d79793735