### PR TITLE
libdrm: Depends on libpciaccess

### DIFF
--- a/libdrm.rb
+++ b/libdrm.rb
@@ -18,7 +18,7 @@ class Libdrm < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "libpciaccess" => :build
+  depends_on "libpciaccess"
   depends_on "libpthread-stubs" => :build
 
   def install


### PR DESCRIPTION
# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?


The Intel driver in particular links to libpciaccess.so

This is part of #84 