### PR TITLE
mesa: Depends on libtool to build

### DIFF
--- a/mesa.rb
+++ b/mesa.rb
@@ -9,6 +9,7 @@ class Mesa < Formula
 
   depends_on "pkg-config" => :build
   depends_on :python => :build
+  depends_on "libtool" => :build
 
   resource "mako" do
     url "https://pypi.python.org/packages/7a/ae/925434246ee90b42e8ef57d3b30a0ab7caf9a2de3e449b876c56dcb48155/Mako-1.0.4.tar.gz"


### PR DESCRIPTION
See https://travis-ci.org/Linuxbrew/homebrew-core/builds/187148642#L5533:

```
Can't exec "glibtoolize": No such file or directory at /home/linuxbrew/.linuxbrew/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 345, <GEN3> line 4.
autoreconf: failed to run glibtoolize: No such file or directory
autoreconf: glibtoolize is needed because this package uses Libtool
```

FYI @DoomHammer 