### PR TITLE
xkeyboardconfig: Depends on intltool for build

### DIFF
--- a/xkeyboardconfig.rb
+++ b/xkeyboardconfig.rb
@@ -7,6 +7,7 @@ class Xkeyboardconfig < Formula
 
   depends_on "pkg-config" => :build
   depends_on "xorg" => :build
+  depends_on "intltool" => :build
 
   def install
     # Standard XORG_CONFIG flags


### PR DESCRIPTION
Fix error:
    Your intltool is too old.  You need intltool 0.30 or later.

Noticed during #238's Travis build https://travis-ci.org/Linuxbrew/homebrew-xorg/builds/187235708#L2939