### PR TITLE
Use HTTPS URL's for *proto formulae

### DIFF
--- a/bigreqsproto.rb
+++ b/bigreqsproto.rb
@@ -1,7 +1,7 @@
 class Bigreqsproto < Formula
   desc "X.Org Protocol Headers: bigreqsproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/bigreqsproto-1.1.2.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/bigreqsproto-1.1.2.tar.bz2"
   sha256 "462116ab44e41d8121bfde947321950370b285a5316612b8fce8334d50751b1e"
   # tag "linuxbrew"
 
@@ -10,7 +10,7 @@ class Bigreqsproto < Formula
     sha256 "204f49efe8ca9252a02645166810b3f1e8fe7d14e7298977cb41fc2bb3b945bd" => :x86_64_linux
   end
 
-  option "with-specs",  "Build specifications"
+  option "with-specs", "Build specifications"
 
   depends_on "pkg-config" => :build
   depends_on "util-macros" => :build

--- a/compositeproto.rb
+++ b/compositeproto.rb
@@ -1,7 +1,7 @@
 class Compositeproto < Formula
   desc "X.Org Protocol Headers: compositeproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/compositeproto-0.4.2.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/compositeproto-0.4.2.tar.bz2"
   sha256 "049359f0be0b2b984a8149c966dd04e8c58e6eade2a4a309cf1126635ccd0cfc"
   # tag "linuxbrew"
 

--- a/damageproto.rb
+++ b/damageproto.rb
@@ -1,7 +1,7 @@
 class Damageproto < Formula
   desc "X.Org Protocol Headers: damageproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/damageproto-1.2.1.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/damageproto-1.2.1.tar.bz2"
   sha256 "5c7c112e9b9ea8a9d5b019e5f17d481ae20f766cb7a4648360e7c1b46fc9fc5b"
   # tag "linuxbrew"
 

--- a/dmxproto.rb
+++ b/dmxproto.rb
@@ -1,7 +1,7 @@
 class Dmxproto < Formula
   desc "X.Org Protocol Headers: dmxproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/dmxproto-2.3.1.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/dmxproto-2.3.1.tar.bz2"
   sha256 "e72051e6a3e06b236d19eed56368117b745ca1e1a27bdc50fd51aa375bea6509"
   # tag "linuxbrew"
 

--- a/dri2proto.rb
+++ b/dri2proto.rb
@@ -1,7 +1,7 @@
 class Dri2proto < Formula
   desc "X.Org Protocol Headers: dri2proto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/dri2proto-2.8.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/dri2proto-2.8.tar.bz2"
   sha256 "f9b55476def44fc7c459b2537d17dbc731e36ed5d416af7ca0b1e2e676f8aa04"
   # tag "linuxbrew"
 

--- a/dri3proto.rb
+++ b/dri3proto.rb
@@ -1,7 +1,7 @@
 class Dri3proto < Formula
   desc "X.Org Protocol Headers: dri3proto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/dri3proto-1.0.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/dri3proto-1.0.tar.bz2"
   sha256 "01be49d70200518b9a6b297131f6cc71f4ea2de17436896af153226a774fc074"
   # tag "linuxbrew"
 

--- a/fixesproto.rb
+++ b/fixesproto.rb
@@ -1,7 +1,7 @@
 class Fixesproto < Formula
   desc "X.Org Protocol Headers: fixesproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/fixesproto-5.0.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/fixesproto-5.0.tar.bz2"
   sha256 "ba2f3f31246bdd3f2a0acf8bd3b09ba99cab965c7fb2c2c92b7dc72870e424ce"
   # tag "linuxbrew"
 

--- a/fontsproto.rb
+++ b/fontsproto.rb
@@ -1,7 +1,7 @@
 class Fontsproto < Formula
   desc "X.Org Protocol Headers: fontsproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/fontsproto-2.1.3.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/fontsproto-2.1.3.tar.bz2"
   sha256 "259046b0dd9130825c4a4c479ba3591d6d0f17a33f54e294b56478729a6e5ab8"
   # tag "linuxbrew"
 

--- a/glproto.rb
+++ b/glproto.rb
@@ -1,7 +1,7 @@
 class Glproto < Formula
   desc "X.Org Protocol Headers: glproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/glproto-1.4.17.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/glproto-1.4.17.tar.bz2"
   sha256 "adaa94bded310a2bfcbb9deb4d751d965fcfe6fb3a2f6d242e2df2d6589dbe40"
   # tag "linuxbrew"
 

--- a/inputproto.rb
+++ b/inputproto.rb
@@ -1,7 +1,7 @@
 class Inputproto < Formula
   desc "X.Org Protocol Headers: inputproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "https://www.x.org/archive//individual/proto/inputproto-2.3.2.tar.bz2"
+  url    "https://www.x.org/archive/individual/proto/inputproto-2.3.2.tar.bz2"
   sha256 "893a6af55733262058a27b38eeb1edc733669f01d404e8581b167f03c03ef31d"
   # tag "linuxbrew"
 

--- a/kbproto.rb
+++ b/kbproto.rb
@@ -1,7 +1,7 @@
 class Kbproto < Formula
   desc "X.Org Protocol Headers: kbproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/kbproto-1.0.7.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/kbproto-1.0.7.tar.bz2"
   sha256 "f882210b76376e3fa006b11dbd890e56ec0942bc56e65d1249ff4af86f90b857"
   # tag "linuxbrew"
 

--- a/presentproto.rb
+++ b/presentproto.rb
@@ -1,7 +1,7 @@
 class Presentproto < Formula
   desc "X.Org Protocol Headers: presentproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/presentproto-1.0.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/presentproto-1.0.tar.bz2"
   sha256 "812c7d48721f909a0f7a2cb1e91f6eead76159a36c4712f4579ca587552839ce"
   # tag "linuxbrew"
 

--- a/randrproto.rb
+++ b/randrproto.rb
@@ -1,7 +1,7 @@
 class Randrproto < Formula
   desc "X.Org Protocol Headers: randrproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/randrproto-1.5.0.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/randrproto-1.5.0.tar.bz2"
   sha256 "4c675533e79cd730997d232c8894b6692174dce58d3e207021b8f860be498468"
   # tag "linuxbrew"
 

--- a/recordproto.rb
+++ b/recordproto.rb
@@ -1,7 +1,7 @@
 class Recordproto < Formula
   desc "X.Org Protocol Headers: recordproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/recordproto-1.14.2.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/recordproto-1.14.2.tar.bz2"
   sha256 "a777548d2e92aa259f1528de3c4a36d15e07a4650d0976573a8e2ff5437e7370"
   # tag "linuxbrew"
 
@@ -10,7 +10,7 @@ class Recordproto < Formula
     sha256 "e23cb1e1cb66b34322fdd448fd79c684b38acb1b0fc7c4f0f6231fe4028ea97e" => :x86_64_linux
   end
 
-  option "with-specs",  "Build specifications"
+  option "with-specs", "Build specifications"
 
   depends_on "pkg-config" => :build
   depends_on "util-macros" => :build

--- a/renderproto.rb
+++ b/renderproto.rb
@@ -1,7 +1,7 @@
 class Renderproto < Formula
   desc "X.Org Protocol Headers: renderproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/renderproto-0.11.1.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/renderproto-0.11.1.tar.bz2"
   sha256 "06735a5b92b20759204e4751ecd6064a2ad8a6246bb65b3078b862a00def2537"
   # tag "linuxbrew"
 
@@ -10,8 +10,8 @@ class Renderproto < Formula
     sha256 "212f70f35f2826cf764f65c116f9a0a6182a460adac7389deb6e74ea8cd7f54d" => :x86_64_linux
   end
 
-  depends_on "pkg-config"         =>  :build
-  depends_on "util-macros"        =>  :build
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
 
   def install
     args = %W[

--- a/resourceproto.rb
+++ b/resourceproto.rb
@@ -1,7 +1,7 @@
 class Resourceproto < Formula
   desc "X.Org Protocol Headers: resourceproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/resourceproto-1.2.0.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/resourceproto-1.2.0.tar.bz2"
   sha256 "3c66003a6bdeb0f70932a9ed3cf57cc554234154378d301e0c5cfa189d8f6818"
   # tag "linuxbrew"
 
@@ -10,8 +10,8 @@ class Resourceproto < Formula
     sha256 "86232aafd92fda6c30e16b16cf03b17df6178495d13ce31baf47f4ec381e2630" => :x86_64_linux
   end
 
-  depends_on "pkg-config"         =>  :build
-  depends_on "util-macros"        =>  :build
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
 
   def install
     args = %W[

--- a/scrnsaverproto.rb
+++ b/scrnsaverproto.rb
@@ -1,7 +1,7 @@
 class Scrnsaverproto < Formula
   desc "X.Org Protocol Headers: scrnsaverproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/scrnsaverproto-1.2.2.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/scrnsaverproto-1.2.2.tar.bz2"
   sha256 "8bb70a8da164930cceaeb4c74180291660533ad3cc45377b30a795d1b85bcd65"
   # tag "linuxbrew"
 
@@ -10,7 +10,7 @@ class Scrnsaverproto < Formula
     sha256 "95e9cd1b7784a93ae47b0a474e83653bdb0bed950852c4dff163fee559b50544" => :x86_64_linux
   end
 
-  option "with-specs",  "Build specifications"
+  option "with-specs", "Build specifications"
 
   depends_on "pkg-config" => :build
   depends_on "util-macros" => :build

--- a/videoproto.rb
+++ b/videoproto.rb
@@ -1,7 +1,7 @@
 class Videoproto < Formula
   desc "X.Org Protocol Headers: videoproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/videoproto-2.3.3.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/videoproto-2.3.3.tar.bz2"
   sha256 "c7803889fd08e6fcaf7b68cc394fb038b2325d1f315e571a6954577e07cca702"
   # tag "linuxbrew"
 
@@ -10,8 +10,8 @@ class Videoproto < Formula
     sha256 "131b8b6037c14e9f384bf80f004009b2b85df8ba6f75b66996cf5b012b17d4bf" => :x86_64_linux
   end
 
-  depends_on "pkg-config"         =>  :build
-  depends_on "util-macros"        =>  :build
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
 
   def install
     args = %W[

--- a/xcmiscproto.rb
+++ b/xcmiscproto.rb
@@ -1,7 +1,7 @@
 class Xcmiscproto < Formula
   desc "X.Org Protocol Headers: xcmiscproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/xcmiscproto-1.2.2.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xcmiscproto-1.2.2.tar.bz2"
   sha256 "b13236869372256c36db79ae39d54214172677fb79e9cdc555dceec80bd9d2df"
   # tag "linuxbrew"
 
@@ -10,7 +10,7 @@ class Xcmiscproto < Formula
     sha256 "46caab02275016fa14276b31198a280a928336004767f5808a78617efbb8814f" => :x86_64_linux
   end
 
-  option "with-specs",  "Build specifications"
+  option "with-specs", "Build specifications"
 
   depends_on "pkg-config" => :build
   depends_on "util-macros" => :build

--- a/xextproto.rb
+++ b/xextproto.rb
@@ -1,7 +1,7 @@
 class Xextproto < Formula
   desc "X.Org Protocol Headers: xextproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/xextproto-7.3.0.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xextproto-7.3.0.tar.bz2"
   sha256 "f3f4b23ac8db9c3a9e0d8edb591713f3d70ef9c3b175970dd8823dfc92aa5bb0"
   # tag "linuxbrew"
 

--- a/xf86bigfontproto.rb
+++ b/xf86bigfontproto.rb
@@ -1,7 +1,7 @@
 class Xf86bigfontproto < Formula
   desc "X.Org Protocol Headers: xf86bigfontproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/xf86bigfontproto-1.2.0.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xf86bigfontproto-1.2.0.tar.bz2"
   sha256 "ba9220e2c4475f5ed2ddaa7287426b30089e4d29bd58d35fad57ba5ea43e1648"
   # tag "linuxbrew"
 
@@ -10,8 +10,8 @@ class Xf86bigfontproto < Formula
     sha256 "af0d2b1eedf5ed2a360b8c2b5dfa9d5eed671d178244e7a20fabb3f317cc437a" => :x86_64_linux
   end
 
-  depends_on "pkg-config"         =>  :build
-  depends_on "util-macros"        =>  :build
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
 
   def install
     args = %W[

--- a/xf86dgaproto.rb
+++ b/xf86dgaproto.rb
@@ -1,7 +1,7 @@
 class Xf86dgaproto < Formula
   desc "X.Org Protocol Headers: xf86dgaproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/xf86dgaproto-2.1.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xf86dgaproto-2.1.tar.bz2"
   sha256 "ac5ef65108e1f2146286e53080975683dae49fc94680042e04bd1e2010e99050"
   # tag "linuxbrew"
 
@@ -10,8 +10,8 @@ class Xf86dgaproto < Formula
     sha256 "99c0abed1c8a54c5cf3e8a6048c9116f0f5450ee56b13cd617fb04569f8b8613" => :x86_64_linux
   end
 
-  depends_on "pkg-config"         =>  :build
-  depends_on "util-macros"        =>  :build
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
 
   def install
     args = %W[

--- a/xf86driproto.rb
+++ b/xf86driproto.rb
@@ -1,7 +1,7 @@
 class Xf86driproto < Formula
   desc "X.Org Protocol Headers: xf86driproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/xf86driproto-2.1.1.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xf86driproto-2.1.1.tar.bz2"
   sha256 "9c4b8d7221cb6dc4309269ccc008a22753698ae9245a398a59df35f1404d661f"
   # tag "linuxbrew"
 
@@ -10,8 +10,8 @@ class Xf86driproto < Formula
     sha256 "add3e319e6aa797042f7b8eb8ca39b9213fdc642330769cd80f1656b007be6fa" => :x86_64_linux
   end
 
-  depends_on "pkg-config"         =>  :build
-  depends_on "util-macros"        =>  :build
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
 
   def install
     args = %W[

--- a/xf86miscproto.rb
+++ b/xf86miscproto.rb
@@ -1,11 +1,11 @@
 class Xf86miscproto < Formula
   desc "X.Org Protocol Headers: xf86miscproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "https://www.x.org/archive//individual/proto/xf86miscproto-0.9.3.tar.bz2"
+  url    "https://www.x.org/archive/individual/proto/xf86miscproto-0.9.3.tar.bz2"
   sha256 "45b8ec6a4a8ca21066dce117e09dcc88539862e616e60fb391de05b36f63b095"
   # tag "linuxbrew"
 
-  depends_on "pkg-config"         =>  :build
+  depends_on "pkg-config" => :build
 
   def install
     args = %W[

--- a/xf86vidmodeproto.rb
+++ b/xf86vidmodeproto.rb
@@ -1,7 +1,7 @@
 class Xf86vidmodeproto < Formula
   desc "X.Org Protocol Headers: xf86vidmodeproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/xf86vidmodeproto-2.3.1.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xf86vidmodeproto-2.3.1.tar.bz2"
   sha256 "45d9499aa7b73203fd6b3505b0259624afed5c16b941bd04fcf123e5de698770"
   # tag "linuxbrew"
 
@@ -10,8 +10,8 @@ class Xf86vidmodeproto < Formula
     sha256 "fcf020ee7ae77f134702e0ae849e7d4211e7db404431ef0a02e6076c66e753cd" => :x86_64_linux
   end
 
-  depends_on "pkg-config"         =>  :build
-  depends_on "util-macros"        =>  :build
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
 
   def install
     args = %W[

--- a/xineramaproto.rb
+++ b/xineramaproto.rb
@@ -1,7 +1,7 @@
 class Xineramaproto < Formula
   desc "X.Org Protocol Headers: xineramaproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/xineramaproto-1.2.1.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xineramaproto-1.2.1.tar.bz2"
   sha256 "977574bb3dc192ecd9c55f59f991ec1dff340be3e31392c95deff423da52485b"
   # tag "linuxbrew"
 
@@ -10,8 +10,8 @@ class Xineramaproto < Formula
     sha256 "42b4c1562aa8cfa5fc8ed49a2226bac13eb01c1b25d00e147870b342dea99ff2" => :x86_64_linux
   end
 
-  depends_on "pkg-config"         =>  :build
-  depends_on "util-macros"        =>  :build
+  depends_on "pkg-config" => :build
+  depends_on "util-macros" => :build
 
   def install
     args = %W[

--- a/xproto.rb
+++ b/xproto.rb
@@ -1,7 +1,7 @@
 class Xproto < Formula
   desc "X.Org Protocol Headers: xproto"
   homepage "http://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/proto/xproto-7.0.31.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xproto-7.0.31.tar.bz2"
   sha256 "c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747"
   # tag "linuxbrew"
 


### PR DESCRIPTION
# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?

As part of this, I switched them all to fetch from www.x.org instead of ftp.x.org. In a few cases, I fixed some whitespace nitpicks too.