### PR TITLE
libglvnd: Depends on libtool for Linuxbrew

### DIFF
--- a/libglvnd.rb
+++ b/libglvnd.rb
@@ -10,6 +10,7 @@ class Libglvnd < Formula
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/util-macros" => :build
   depends_on "autoconf" => :build
+  depends_on "libtool" => :build
 
   depends_on "linuxbrew/xorg/libx11"
   depends_on "linuxbrew/xorg/libxext"


### PR DESCRIPTION
Under superenv it can't find glibtoolize.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

