### PR TITLE
libvdpau-va-gl: depends on glib for Linuxbrew

### DIFF
--- a/libvdpau-va-gl.rb
+++ b/libvdpau-va-gl.rb
@@ -16,6 +16,7 @@ class LibvdpauVaGl < Formula
   depends_on "linuxbrew/xorg/glu"
   depends_on "linuxbrew/xorg/libva"
   depends_on "linuxbrew/xorg/libvdpau"
+  depends_on "glib"
 
   def install
     args = std_cmake_args


### PR DESCRIPTION
I'm expecting this to fail; I just want to see *how* it fails.