### PR TITLE
TEST: see what happens when xkeyboardconfig depends strictly on libx11

### DIFF
--- a/xkeyboardconfig.rb
+++ b/xkeyboardconfig.rb
@@ -1,9 +1,9 @@
 class Xkeyboardconfig < Formula
   desc "Keyboard configuration database for the X Window System"
   homepage "https://xorg.freedesktop.org"
-  url "https://xorg.freedesktop.org/archive/individual/data/xkeyboard-config/xkeyboard-config-2.17.tar.bz2"
-  mirror "ftp://ftp.x.org/pub/individual/data/xkeyboard-config/xkeyboard-config-2.17.tar.bz2"
-  sha256 "dec6be44bd31775cdc1ab95bfd75d5f2c0055613eeca8b4e9c6480b183430701"
+  url "https://xorg.freedesktop.org/archive/individual/data/xkeyboard-config/xkeyboard-config-2.20.tar.bz2"
+  mirror "ftp://ftp.x.org/pub/individual/data/xkeyboard-config/xkeyboard-config-2.20.tar.bz2"
+  sha256 "d1bfc72553c4e3ef1cd6f13eec0488cf940498b612ab8a0b362e7090c94bc134"
 
   bottle do
     cellar :any_skip_relocation
@@ -11,8 +11,8 @@ class Xkeyboardconfig < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "linuxbrew/xorg/xorg" => :build
   depends_on "intltool" => :build
+  depends_on "linuxbrew/xorg/libx11"
 
   def install
     # Standard XORG_CONFIG flags


### PR DESCRIPTION
Do not merge this; it's just a test to see what happens when `xkeyboardconfig` depends solely on `libx11`. (Part of reviewing #269)