### PR TITLE
libva: build X11 bindings

### DIFF
--- a/libva.rb
+++ b/libva.rb
@@ -26,6 +26,10 @@ class Libva < Formula
   depends_on "linuxbrew/xorg/libdrm"
   depends_on "linuxbrew/xorg/wayland" => :recommended
 
+  # Needed for X11 bindings
+  depends_on "linuxbrew/xorg/libxext"
+  depends_on "linuxbrew/xorg/libxfixes"
+
   depends_on "libtool" => :build if build.without?("wayland")
 
   def install

--- a/libva.rb
+++ b/libva.rb
@@ -22,8 +22,11 @@ class Libva < Formula
   # Build-time
   depends_on "pkg-config" => :build
   depends_on "autoconf" => :build
+
   depends_on "linuxbrew/xorg/libdrm"
   depends_on "linuxbrew/xorg/wayland" => :recommended
+
+  depends_on "libtool" => :build if build.without?("wayland")
 
   def install
     args = %W[


### PR DESCRIPTION
autoreconf is only called if wayland is not requested,
but if it is, libtool is needed.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

