### PR TITLE
libva: Depends on libtool to build without Wayland

### DIFF
--- a/libva.rb
+++ b/libva.rb
@@ -22,8 +22,11 @@ class Libva < Formula
   # Build-time
   depends_on "pkg-config" => :build
   depends_on "autoconf" => :build
+
   depends_on "linuxbrew/xorg/libdrm"
   depends_on "linuxbrew/xorg/wayland" => :recommended
+
+  depends_on "libtool" => :build if build.without?("wayland")
 
   def install
     args = %W[


### PR DESCRIPTION
Reopening a limited version of #291 