### PR TITLE
Mass style fix: remove extraneous spaces after url

### DIFF
--- a/bdftopcf.rb
+++ b/bdftopcf.rb
@@ -2,7 +2,7 @@ class Bdftopcf < Formula
   desc "X.Org Applications: bdftopcf"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/bdftopcf-1.0.5.tar.bz2"
+  url "https://www.x.org/pub/individual/app/bdftopcf-1.0.5.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/bdftopcf-1.0.5.tar.bz2"
   sha256 "38f447be0c61f94c473f128cf519dd0cff63b5d7775240a2e895a183a61e2026"
   # tag "linuxbrew"

--- a/encodings.rb
+++ b/encodings.rb
@@ -2,7 +2,7 @@ class Encodings < Formula
   desc "X.Org Fonts: encodings"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/encodings-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/font/encodings-1.0.4.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/encodings-1.0.4.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/encodings-1.0.4.tar.bz2"
   sha256 "ced6312988a45d23812c2ac708b4595f63fd7a49c4dcd9f66bdcd50d1057d539"

--- a/font-adobe-100dpi.rb
+++ b/font-adobe-100dpi.rb
@@ -2,7 +2,7 @@ class FontAdobe100dpi < Formula
   desc "X.Org Fonts: font adobe 100dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-adobe-100dpi-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-adobe-100dpi-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-adobe-100dpi-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-adobe-100dpi-1.0.3.tar.bz2"
   sha256 "b2c08433eab5cb202470aa9f779efefce8d9cab2534f34f3aa4a31d05671c054"

--- a/font-adobe-75dpi.rb
+++ b/font-adobe-75dpi.rb
@@ -2,7 +2,7 @@ class FontAdobe75dpi < Formula
   desc "X.Org Fonts: font adobe 75dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-adobe-75dpi-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-adobe-75dpi-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-adobe-75dpi-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-adobe-75dpi-1.0.3.tar.bz2"
   sha256 "c6024a1e4a1e65f413f994dd08b734efd393ce0a502eb465deb77b9a36db4d09"

--- a/font-adobe-utopia-100dpi.rb
+++ b/font-adobe-utopia-100dpi.rb
@@ -2,7 +2,7 @@ class FontAdobeUtopia100dpi < Formula
   desc "X.Org Fonts: font adobe utopia 100dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-adobe-utopia-100dpi-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-adobe-utopia-100dpi-1.0.4.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-adobe-utopia-100dpi-1.0.4.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-adobe-utopia-100dpi-1.0.4.tar.bz2"
   sha256 "d16f5e3f227cc6dd07a160a71f443559682dbc35f1c056a5385085aaec4fada5"

--- a/font-adobe-utopia-75dpi.rb
+++ b/font-adobe-utopia-75dpi.rb
@@ -2,7 +2,7 @@ class FontAdobeUtopia75dpi < Formula
   desc "X.Org Fonts: font adobe utopia 75dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-adobe-utopia-75dpi-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-adobe-utopia-75dpi-1.0.4.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-adobe-utopia-75dpi-1.0.4.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-adobe-utopia-75dpi-1.0.4.tar.bz2"
   sha256 "8732719c61f3661c8bad63804ebfd54fc7de21ab848e9a26a19b1778ef8b5c94"

--- a/font-adobe-utopia-type1.rb
+++ b/font-adobe-utopia-type1.rb
@@ -2,7 +2,7 @@ class FontAdobeUtopiaType1 < Formula
   desc "X.Org Fonts: font adobe utopia type1"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-adobe-utopia-type1-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-adobe-utopia-type1-1.0.4.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-adobe-utopia-type1-1.0.4.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-adobe-utopia-type1-1.0.4.tar.bz2"
   sha256 "979435105f897a70f8993fa02c8362160b0513366c2ab896965416f96dbb8077"

--- a/font-alias.rb
+++ b/font-alias.rb
@@ -2,7 +2,7 @@ class FontAlias < Formula
   desc "X.Org Fonts: font alias"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-alias-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-alias-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-alias-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-alias-1.0.3.tar.bz2"
   sha256 "8b453b2aae1cfa8090009ca037037b8c5e333550651d5a158b7264ce1d472c9a"

--- a/font-arabic-misc.rb
+++ b/font-arabic-misc.rb
@@ -2,7 +2,7 @@ class FontArabicMisc < Formula
   desc "X.Org Fonts: font arabic misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-arabic-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-arabic-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-arabic-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-arabic-misc-1.0.3.tar.bz2"
   sha256 "505d9b12a7093389e67a925dfda6346bde26d114c67f0cdca7aeda6e5d3344f4"

--- a/font-bh-100dpi.rb
+++ b/font-bh-100dpi.rb
@@ -2,7 +2,7 @@ class FontBh100dpi < Formula
   desc "X.Org Fonts: font bh 100dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bh-100dpi-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bh-100dpi-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bh-100dpi-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bh-100dpi-1.0.3.tar.bz2"
   sha256 "23c07162708e4b79eb33095c8bfa62c783717a9431254bbf44863734ea239481"

--- a/font-bh-75dpi.rb
+++ b/font-bh-75dpi.rb
@@ -2,7 +2,7 @@ class FontBh75dpi < Formula
   desc "X.Org Fonts: font bh 75dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bh-75dpi-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bh-75dpi-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bh-75dpi-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bh-75dpi-1.0.3.tar.bz2"
   sha256 "3486aa51ac92c646a448fe899c5c3dae0024b1fef724d5100d52640d1cac721c"

--- a/font-bh-lucidatypewriter-100dpi.rb
+++ b/font-bh-lucidatypewriter-100dpi.rb
@@ -2,7 +2,7 @@ class FontBhLucidatypewriter100dpi < Formula
   desc "X.Org Fonts: font bh lucidatypewriter 100dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bh-lucidatypewriter-100dpi-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bh-lucidatypewriter-100dpi-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bh-lucidatypewriter-100dpi-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bh-lucidatypewriter-100dpi-1.0.3.tar.bz2"
   sha256 "62a83363c2536095fda49d260d21e0847675676e4e3415054064cbdffa641fbb"

--- a/font-bh-lucidatypewriter-75dpi.rb
+++ b/font-bh-lucidatypewriter-75dpi.rb
@@ -2,7 +2,7 @@ class FontBhLucidatypewriter75dpi < Formula
   desc "X.Org Fonts: font bh lucidatypewriter 75dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bh-lucidatypewriter-75dpi-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bh-lucidatypewriter-75dpi-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bh-lucidatypewriter-75dpi-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bh-lucidatypewriter-75dpi-1.0.3.tar.bz2"
   sha256 "4ac16afbe205480cc5572e2977ea63488c543d05be0ea8e5a94c845a6eebcb31"

--- a/font-bh-ttf.rb
+++ b/font-bh-ttf.rb
@@ -2,7 +2,7 @@ class FontBhTtf < Formula
   desc "X.Org Fonts: font bh ttf"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bh-ttf-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bh-ttf-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bh-ttf-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bh-ttf-1.0.3.tar.bz2"
   sha256 "1b4bea63271b4db0726b5b52c97994c3313b6023510349226908090501abd25f"

--- a/font-bh-type1.rb
+++ b/font-bh-type1.rb
@@ -2,7 +2,7 @@ class FontBhType1 < Formula
   desc "X.Org Fonts: font bh type1"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bh-type1-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bh-type1-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bh-type1-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bh-type1-1.0.3.tar.bz2"
   sha256 "761455a297486f3927a85d919b5c948d1d324181d4bea6c95d542504b68a63c1"

--- a/font-bitstream-100dpi.rb
+++ b/font-bitstream-100dpi.rb
@@ -2,7 +2,7 @@ class FontBitstream100dpi < Formula
   desc "X.Org Fonts: font bitstream 100dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bitstream-100dpi-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bitstream-100dpi-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bitstream-100dpi-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bitstream-100dpi-1.0.3.tar.bz2"
   sha256 "ebe0d7444e3d7c8da7642055ac2206f0190ee060700d99cd876f8fc9964cb6ce"

--- a/font-bitstream-75dpi.rb
+++ b/font-bitstream-75dpi.rb
@@ -2,7 +2,7 @@ class FontBitstream75dpi < Formula
   desc "X.Org Fonts: font bitstream 75dpi"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bitstream-75dpi-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bitstream-75dpi-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bitstream-75dpi-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bitstream-75dpi-1.0.3.tar.bz2"
   sha256 "ba3f5e4610c07bd5859881660753ec6d75d179f26fc967aa776dbb3d5d5cf48e"

--- a/font-bitstream-type1.rb
+++ b/font-bitstream-type1.rb
@@ -2,7 +2,7 @@ class FontBitstreamType1 < Formula
   desc "X.Org Fonts: font bitstream type1"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-bitstream-type1-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-bitstream-type1-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-bitstream-type1-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-bitstream-type1-1.0.3.tar.bz2"
   sha256 "c6ea0569adad2c577f140328dc3302e729cb1b1ea90cd0025caf380625f8a688"

--- a/font-cronyx-cyrillic.rb
+++ b/font-cronyx-cyrillic.rb
@@ -2,7 +2,7 @@ class FontCronyxCyrillic < Formula
   desc "X.Org Fonts: font cronyx cyrillic"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-cronyx-cyrillic-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-cronyx-cyrillic-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-cronyx-cyrillic-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-cronyx-cyrillic-1.0.3.tar.bz2"
   sha256 "6e8631936157677c77ba032b5c7b1fb3cb2ee872dbcea0444f12cd602cd9212a"

--- a/font-cursor-misc.rb
+++ b/font-cursor-misc.rb
@@ -2,7 +2,7 @@ class FontCursorMisc < Formula
   desc "X.Org Fonts: font cursor misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-cursor-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-cursor-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-cursor-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-cursor-misc-1.0.3.tar.bz2"
   sha256 "17363eb35eece2e08144da5f060c70103b59d0972b4f4d77fd84c9a7a2dba635"

--- a/font-daewoo-misc.rb
+++ b/font-daewoo-misc.rb
@@ -2,7 +2,7 @@ class FontDaewooMisc < Formula
   desc "X.Org Fonts: font daewoo misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-daewoo-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-daewoo-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-daewoo-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-daewoo-misc-1.0.3.tar.bz2"
   sha256 "bc65de70bee12698caa95b523d3b652c056347e17b68cc8b5d6bbdff235c4be8"

--- a/font-dec-misc.rb
+++ b/font-dec-misc.rb
@@ -2,7 +2,7 @@ class FontDecMisc < Formula
   desc "X.Org Fonts: font dec misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-dec-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-dec-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-dec-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-dec-misc-1.0.3.tar.bz2"
   sha256 "e19ddf8b5f8de914d81675358fdfe37762e9ce524887cc983adef34f2850ff7b"

--- a/font-ibm-type1.rb
+++ b/font-ibm-type1.rb
@@ -2,7 +2,7 @@ class FontIbmType1 < Formula
   desc "X.Org Fonts: font ibm type1"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-ibm-type1-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-ibm-type1-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-ibm-type1-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-ibm-type1-1.0.3.tar.bz2"
   sha256 "fddb28d3db5a07f4b4ca15388488a9680a10e1367a18f358f903b2a608a5d2df"

--- a/font-isas-misc.rb
+++ b/font-isas-misc.rb
@@ -2,7 +2,7 @@ class FontIsasMisc < Formula
   desc "X.Org Fonts: font isas misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-isas-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-isas-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-isas-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-isas-misc-1.0.3.tar.bz2"
   sha256 "5824ab4b485951107dd245b8f7717d2822f1a6dbf6cea98f1ac7f49905c0a867"

--- a/font-jis-misc.rb
+++ b/font-jis-misc.rb
@@ -2,7 +2,7 @@ class FontJisMisc < Formula
   desc "X.Org Fonts: font jis misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-jis-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-jis-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-jis-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-jis-misc-1.0.3.tar.bz2"
   sha256 "2b18ce10b367ebafe95a17de799b6db9a24e2337188d124adaf68af05b1fac65"

--- a/font-micro-misc.rb
+++ b/font-micro-misc.rb
@@ -2,7 +2,7 @@ class FontMicroMisc < Formula
   desc "X.Org Fonts: font micro misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-micro-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-micro-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-micro-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-micro-misc-1.0.3.tar.bz2"
   sha256 "9a3381c10f32d9511f0ad4179df395914c50779103c16cddf7017f5220ed8db6"

--- a/font-misc-cyrillic.rb
+++ b/font-misc-cyrillic.rb
@@ -2,7 +2,7 @@ class FontMiscCyrillic < Formula
   desc "X.Org Fonts: font misc cyrillic"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-misc-cyrillic-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-misc-cyrillic-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-misc-cyrillic-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-misc-cyrillic-1.0.3.tar.bz2"
   sha256 "e40fe3e3323c62b738550795457ad555c70c008aa91b5912dfd46f8e745f5e60"

--- a/font-misc-ethiopic.rb
+++ b/font-misc-ethiopic.rb
@@ -2,7 +2,7 @@ class FontMiscEthiopic < Formula
   desc "X.Org Fonts: font misc ethiopic"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-misc-ethiopic-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-misc-ethiopic-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-misc-ethiopic-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-misc-ethiopic-1.0.3.tar.bz2"
   sha256 "53cb1fd83afdbe7939c0eac34003676ee0e6023216892d98054db90b703c98a5"

--- a/font-misc-meltho.rb
+++ b/font-misc-meltho.rb
@@ -2,7 +2,7 @@ class FontMiscMeltho < Formula
   desc "X.Org Fonts: font misc meltho"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-misc-meltho-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-misc-meltho-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-misc-meltho-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-misc-meltho-1.0.3.tar.bz2"
   sha256 "3721323f13855cf7ca609115a1f7b182491e9b2b9c6e01eb1a2c7f8edd480791"

--- a/font-misc-misc.rb
+++ b/font-misc-misc.rb
@@ -2,7 +2,7 @@ class FontMiscMisc < Formula
   desc "X.Org Fonts: font misc misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-misc-misc-1.1.2.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-misc-misc-1.1.2.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-misc-misc-1.1.2.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-misc-misc-1.1.2.tar.bz2"
   sha256 "b8e77940e4e1769dc47ef1805918d8c9be37c708735832a07204258bacc11794"

--- a/font-mutt-misc.rb
+++ b/font-mutt-misc.rb
@@ -2,7 +2,7 @@ class FontMuttMisc < Formula
   desc "X.Org Fonts: font mutt misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-mutt-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-mutt-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-mutt-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-mutt-misc-1.0.3.tar.bz2"
   sha256 "bd5f7adb34367c197773a9801df5bce7b019664941900b2a31fbfe1ff2830f8f"

--- a/font-schumacher-misc.rb
+++ b/font-schumacher-misc.rb
@@ -2,7 +2,7 @@ class FontSchumacherMisc < Formula
   desc "X.Org Fonts: font schumacher misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-schumacher-misc-1.1.2.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-schumacher-misc-1.1.2.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-schumacher-misc-1.1.2.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-schumacher-misc-1.1.2.tar.bz2"
   sha256 "e444028656e0767e2eddc6d9aca462b16a2be75a47244dbc199b2c44eca87e5a"

--- a/font-screen-cyrillic.rb
+++ b/font-screen-cyrillic.rb
@@ -2,7 +2,7 @@ class FontScreenCyrillic < Formula
   desc "X.Org Fonts: font screen cyrillic"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-screen-cyrillic-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-screen-cyrillic-1.0.4.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-screen-cyrillic-1.0.4.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-screen-cyrillic-1.0.4.tar.bz2"
   sha256 "824231e8dffe15299454e47259f29d98001c9cf8ad3d6b5171399e4d71705e79"

--- a/font-sony-misc.rb
+++ b/font-sony-misc.rb
@@ -2,7 +2,7 @@ class FontSonyMisc < Formula
   desc "X.Org Fonts: font sony misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-sony-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-sony-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-sony-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-sony-misc-1.0.3.tar.bz2"
   sha256 "2043a326ba347c9da5ca1e9bc363e2521c3ea40b43b1f9662d333efd4867cff5"

--- a/font-sun-misc.rb
+++ b/font-sun-misc.rb
@@ -2,7 +2,7 @@ class FontSunMisc < Formula
   desc "X.Org Fonts: font sun misc"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-sun-misc-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-sun-misc-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-sun-misc-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-sun-misc-1.0.3.tar.bz2"
   sha256 "481f4fcbbf7005658b080b3cf342c8c76de752e77f47958b2b383de73266d2e0"

--- a/font-util.rb
+++ b/font-util.rb
@@ -2,7 +2,7 @@ class FontUtil < Formula
   desc "X.Org font package creation/installation utilities"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-util-1.3.1.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-util-1.3.1.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-util-1.3.1.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-util-1.3.1.tar.bz2"
   sha256 "aa7ebdb0715106dd255082f2310dbaa2cd7e225957c2a77d719720c7cc92b921"

--- a/font-winitzki-cyrillic.rb
+++ b/font-winitzki-cyrillic.rb
@@ -2,7 +2,7 @@ class FontWinitzkiCyrillic < Formula
   desc "X.Org Fonts: font winitzki cyrillic"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-winitzki-cyrillic-1.0.3.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-winitzki-cyrillic-1.0.3.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-winitzki-cyrillic-1.0.3.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-winitzki-cyrillic-1.0.3.tar.bz2"
   sha256 "abd13b63d02fcaec488686c23683e5cf640b43bd32f8ca22eeae6f84df0a36a0"

--- a/font-xfree86-type1.rb
+++ b/font-xfree86-type1.rb
@@ -2,7 +2,7 @@ class FontXfree86Type1 < Formula
   desc "X.Org Fonts: font xfree86 type1"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7font.html
-  url    "https://www.x.org/pub/individual/font/font-xfree86-type1-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/font/font-xfree86-type1-1.0.4.tar.bz2"
   mirror "https://xorg.freedesktop.org/archive/individual/font/font-xfree86-type1-1.0.4.tar.bz2"
   mirror "https://ftp.x.org/archive/individual/font/font-xfree86-type1-1.0.4.tar.bz2"
   sha256 "caebf42aec7be7f3bd40e0f232d6f34881b853dc84acfcdf7458358701fbe34a"

--- a/fontcacheproto.rb
+++ b/fontcacheproto.rb
@@ -2,7 +2,7 @@ class Fontcacheproto < Formula
   desc "X.Org Proto: fontcacheproto"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/proto/fontcacheproto-0.1.3.tar.bz2"
+  url "https://www.x.org/pub/individual/proto/fontcacheproto-0.1.3.tar.bz2"
   mirror "https://ftp.x.org/pub/individual/proto/fontcacheproto-0.1.3.tar.bz2"
   sha256 "1dcaa659d416272ff68e567d1910ccc1e369768f13b983cffcccd6c563dbe3cb"
   # tag "linuxbrew"

--- a/iceauth.rb
+++ b/iceauth.rb
@@ -2,7 +2,7 @@ class Iceauth < Formula
   desc "X.Org Applications: iceauth"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/iceauth-1.0.7.tar.bz2"
+  url "https://www.x.org/pub/individual/app/iceauth-1.0.7.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/iceauth-1.0.7.tar.bz2"
   sha256 "1216af2dee99b318fcf8bf9a259915273bcb37a7f1e7859af4f15d0ebf6f3f0a"
   # tag "linuxbrew"

--- a/inputproto.rb
+++ b/inputproto.rb
@@ -1,7 +1,7 @@
 class Inputproto < Formula
   desc "X.Org Protocol Headers: inputproto"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "https://www.x.org/archive/individual/proto/inputproto-2.3.2.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/inputproto-2.3.2.tar.bz2"
   sha256 "893a6af55733262058a27b38eeb1edc733669f01d404e8581b167f03c03ef31d"
   # tag "linuxbrew"
 

--- a/libdmx.rb
+++ b/libdmx.rb
@@ -1,7 +1,7 @@
 class Libdmx < Formula
   desc "X.Org Libraries: libdmx"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libdmx-1.1.3.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libdmx-1.1.3.tar.bz2"
   sha256 "c97da36d2e56a2d7b6e4f896241785acc95e97eb9557465fd66ba2a155a7b201"
   # tag "linuxbrew"
 

--- a/libevdev.rb
+++ b/libevdev.rb
@@ -1,7 +1,7 @@
 class Libevdev < Formula
   desc "Wrapper library for evdev devices"
   homepage "https://www.freedesktop.org/wiki/Software/libevdev/"
-  url    "https://www.freedesktop.org/software/libevdev/libevdev-1.5.2.tar.xz"
+  url "https://www.freedesktop.org/software/libevdev/libevdev-1.5.2.tar.xz"
   sha256 "5ee2163656a61f5703cb5c08a05c9471ffb7b640bfbe2c55194ea50d908f629b"
   # tag "linuxbrew"
 

--- a/libfontenc.rb
+++ b/libfontenc.rb
@@ -1,7 +1,7 @@
 class Libfontenc < Formula
   desc "X.Org Libraries: libfontenc"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libfontenc-1.1.3.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libfontenc-1.1.3.tar.bz2"
   sha256 "70588930e6fc9542ff38e0884778fbc6e6febf21adbab92fd8f524fe60aefd21"
   # tag "linuxbrew"
 

--- a/libfs.rb
+++ b/libfs.rb
@@ -1,7 +1,7 @@
 class Libfs < Formula
   desc "X.Org Libraries: libFS"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libFS-1.0.7.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libFS-1.0.7.tar.bz2"
   sha256 "2e9d4c07026a7401d4fa4ffae86e6ac7fec83f50f3268fa85f52718e479dc4f3"
   # tag "linuxbrew"
 

--- a/libice.rb
+++ b/libice.rb
@@ -1,7 +1,7 @@
 class Libice < Formula
   desc "X.Org Libraries: libICE"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libICE-1.0.9.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libICE-1.0.9.tar.bz2"
   sha256 "8f7032f2c1c64352b5423f6b48a8ebdc339cc63064af34d66a6c9aa79759e202"
   # tag "linuxbrew"
 

--- a/libsm.rb
+++ b/libsm.rb
@@ -1,7 +1,7 @@
 class Libsm < Formula
   desc "X.Org Libraries: libSM"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libSM-1.2.2.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libSM-1.2.2.tar.bz2"
   sha256 "0baca8c9f5d934450a70896c4ad38d06475521255ca63b717a6510fdb6e287bd"
   # tag "linuxbrew"
 

--- a/libxau.rb
+++ b/libxau.rb
@@ -1,7 +1,7 @@
 class Libxau < Formula
   desc "X11 Authorization Protocol"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXau-1.0.8.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXau-1.0.8.tar.bz2"
   sha256 "fdd477320aeb5cdd67272838722d6b7d544887dfe7de46e1e7cc0c27c2bea4f2"
   # tag "linuxbrew"
 

--- a/libxaw.rb
+++ b/libxaw.rb
@@ -1,7 +1,7 @@
 class Libxaw < Formula
   desc "X.Org Libraries: libXaw"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXaw-1.0.13.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXaw-1.0.13.tar.bz2"
   sha256 "8ef8067312571292ccc2bbe94c41109dcf022ea5a4ec71656a83d8cce9edb0cd"
   # tag "linuxbrew"
 

--- a/libxcomposite.rb
+++ b/libxcomposite.rb
@@ -1,7 +1,7 @@
 class Libxcomposite < Formula
   desc "X.Org Libraries: libXcomposite"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXcomposite-0.4.4.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXcomposite-0.4.4.tar.bz2"
   sha256 "ede250cd207d8bee4a338265c3007d7a68d5aca791b6ac41af18e9a2aeb34178"
   # tag "linuxbrew"
 

--- a/libxcursor.rb
+++ b/libxcursor.rb
@@ -1,7 +1,7 @@
 class Libxcursor < Formula
   desc "X.Org Libraries: libXcursor"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXcursor-1.1.14.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXcursor-1.1.14.tar.bz2"
   sha256 "9bc6acb21ca14da51bda5bc912c8955bc6e5e433f0ab00c5e8bef842596c33df"
   # tag "linuxbrew"
 

--- a/libxdamage.rb
+++ b/libxdamage.rb
@@ -1,7 +1,7 @@
 class Libxdamage < Formula
   desc "X.Org Libraries: libXdamage"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXdamage-1.1.4.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXdamage-1.1.4.tar.bz2"
   sha256 "7c3fe7c657e83547f4822bfde30a90d84524efb56365448768409b77f05355ad"
   # tag "linuxbrew"
 

--- a/libxdmcp.rb
+++ b/libxdmcp.rb
@@ -1,7 +1,7 @@
 class Libxdmcp < Formula
   desc "X Display Manager Control Protocol"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXdmcp-1.1.2.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXdmcp-1.1.2.tar.bz2"
   sha256 "81fe09867918fff258296e1e1e159f0dc639cb30d201c53519f25ab73af4e4e2"
   # tag "linuxbrew"
 

--- a/libxext.rb
+++ b/libxext.rb
@@ -1,7 +1,7 @@
 class Libxext < Formula
   desc "X.Org Libraries: libXext"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXext-1.3.3.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXext-1.3.3.tar.bz2"
   sha256 "b518d4d332231f313371fdefac59e3776f4f0823bcb23cf7c7305bfb57b16e35"
   # tag "linuxbrew"
 

--- a/libxfontcache.rb
+++ b/libxfontcache.rb
@@ -1,7 +1,7 @@
 class Libxfontcache < Formula
   desc "X.Org Libraries: libXfontCache"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "https://www.x.org/archive//individual/lib/libXfontcache-1.0.5.tar.gz"
+  url "https://www.x.org/archive//individual/lib/libXfontcache-1.0.5.tar.gz"
   sha256 "fdba75307a0983d2566554e0e9effa7079551f1b7b46e8de642d067998619659"
   # tag "linuxbrew"
 

--- a/libxft.rb
+++ b/libxft.rb
@@ -1,7 +1,7 @@
 class Libxft < Formula
   desc "X.Org Libraries: libXft"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXft-2.3.2.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXft-2.3.2.tar.bz2"
   sha256 "f5a3c824761df351ca91827ac221090943ef28b248573486050de89f4bfcdc4c"
   # tag "linuxbrew"
 

--- a/libxi.rb
+++ b/libxi.rb
@@ -1,7 +1,7 @@
 class Libxi < Formula
   desc "X.Org Libraries: libXi"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXi-1.7.9.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXi-1.7.9.tar.bz2"
   sha256 "c2e6b8ff84f9448386c1b5510a5cf5a16d788f76db018194dacdc200180faf45"
   # tag "linuxbrew"
 

--- a/libxinerama.rb
+++ b/libxinerama.rb
@@ -1,7 +1,7 @@
 class Libxinerama < Formula
   desc "X.Org Libraries: libXinerama"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXinerama-1.1.3.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXinerama-1.1.3.tar.bz2"
   sha256 "7a45699f1773095a3f821e491cbd5e10c887c5a5fce5d8d3fced15c2ff7698e2"
   # tag "linuxbrew"
 

--- a/libxkbfile.rb
+++ b/libxkbfile.rb
@@ -1,7 +1,7 @@
 class Libxkbfile < Formula
   desc "X.Org Libraries: libxkbfile"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libxkbfile-1.0.9.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libxkbfile-1.0.9.tar.bz2"
   sha256 "51817e0530961975d9513b773960b4edd275f7d5c72293d5a151ed4f42aeb16a"
   # tag "linuxbrew"
 

--- a/libxmu.rb
+++ b/libxmu.rb
@@ -1,7 +1,7 @@
 class Libxmu < Formula
   desc "X.Org Libraries: libXmu"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXmu-1.1.2.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXmu-1.1.2.tar.bz2"
   sha256 "756edc7c383254eef8b4e1b733c3bf1dc061b523c9f9833ac7058378b8349d0b"
   # tag "linuxbrew"
 

--- a/libxscrnsaver.rb
+++ b/libxscrnsaver.rb
@@ -1,7 +1,7 @@
 class Libxscrnsaver < Formula
   desc "X.Org Libraries: libXScrnSaver"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXScrnSaver-1.2.2.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXScrnSaver-1.2.2.tar.bz2"
   sha256 "8ff1efa7341c7f34bcf9b17c89648d6325ddaae22e3904e091794e0b4426ce1d"
   # tag "linuxbrew"
 

--- a/libxshmfence.rb
+++ b/libxshmfence.rb
@@ -1,7 +1,7 @@
 class Libxshmfence < Formula
   desc "X.Org Libraries: libxshmfence"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libxshmfence-1.2.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libxshmfence-1.2.tar.bz2"
   sha256 "d21b2d1fd78c1efbe1f2c16dae1cb23f8fd231dcf891465b8debe636a9054b0c"
   # tag "linuxbrew"
 

--- a/libxt.rb
+++ b/libxt.rb
@@ -1,7 +1,7 @@
 class Libxt < Formula
   desc "X.Org Libraries: libXt"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXt-1.1.5.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXt-1.1.5.tar.bz2"
   sha256 "46eeb6be780211fdd98c5109286618f6707712235fdd19df4ce1e6954f349f1a"
   # tag "linuxbrew"
 

--- a/libxxf86dga.rb
+++ b/libxxf86dga.rb
@@ -1,7 +1,7 @@
 class Libxxf86dga < Formula
   desc "X.Org Libraries: libXxf86dga"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXxf86dga-1.1.4.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXxf86dga-1.1.4.tar.bz2"
   sha256 "8eecd4b6c1df9a3704c04733c2f4fa93ef469b55028af5510b25818e2456c77e"
   # tag "linuxbrew"
 

--- a/libxxf86misc.rb
+++ b/libxxf86misc.rb
@@ -1,7 +1,7 @@
 class Libxxf86misc < Formula
   desc "X.Org Libraries: libXxf86misc"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "https://www.x.org/archive//individual/lib/libXxf86misc-1.0.3.tar.gz"
+  url "https://www.x.org/archive//individual/lib/libXxf86misc-1.0.3.tar.gz"
   sha256 "358f692f793af00f6ef4c7a8566c1bcaeeea37e417337db3f519522cc1df3946"
   # tag "linuxbrew"
 

--- a/libxxf86vm.rb
+++ b/libxxf86vm.rb
@@ -1,7 +1,7 @@
 class Libxxf86vm < Formula
   desc "X.Org Libraries: libXxf86vm"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/libXxf86vm-1.1.4.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/libXxf86vm-1.1.4.tar.bz2"
   sha256 "afee27f93c5f31c0ad582852c0fb36d50e4de7cd585fcf655e278a633d85cd57"
   # tag "linuxbrew"
 

--- a/luit.rb
+++ b/luit.rb
@@ -2,7 +2,7 @@ class Luit < Formula
   desc "X.Org Applications: luit"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/luit-1.1.1.tar.bz2"
+  url "https://www.x.org/pub/individual/app/luit-1.1.1.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/luit-1.1.1.tar.bz2"
   sha256 "30b0e787cb07a0f504b70f1d6123930522111ce9d4276f6683a69b322b49c636"
   # tag "linuxbrew"

--- a/mkfontdir.rb
+++ b/mkfontdir.rb
@@ -2,7 +2,7 @@ class Mkfontdir < Formula
   desc "X.Org Applications: mkfontdir"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/mkfontdir-1.0.7.tar.bz2"
+  url "https://www.x.org/pub/individual/app/mkfontdir-1.0.7.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/mkfontdir-1.0.7.tar.bz2"
   sha256 "56d52a482df130484e51fd066d1b6eda7c2c02ddbc91fe6e2be1b9c4e7306530"
   # tag "linuxbrew"

--- a/mkfontscale.rb
+++ b/mkfontscale.rb
@@ -2,7 +2,7 @@ class Mkfontscale < Formula
   desc "X.Org Applications: mkfontscale"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/mkfontscale-1.1.2.tar.bz2"
+  url "https://www.x.org/pub/individual/app/mkfontscale-1.1.2.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/mkfontscale-1.1.2.tar.bz2"
   sha256 "8c6d5228af885477b9aec60ca6f172578e7d2de42234357af62fb00439453f20"
   # tag "linuxbrew"

--- a/mtdev.rb
+++ b/mtdev.rb
@@ -1,7 +1,7 @@
 class Mtdev < Formula
   desc "Multitouch Protocol Translation Library"
   homepage "http://bitmath.org"
-  url    "http://bitmath.org/code/mtdev/mtdev-1.1.5.tar.bz2"
+  url "http://bitmath.org/code/mtdev/mtdev-1.1.5.tar.bz2"
   sha256 "6677d5708a7948840de734d8b4675d5980d4561171c5a8e89e54adf7a13eba7f"
   # tag "linuxbrew"
 

--- a/pciutils.rb
+++ b/pciutils.rb
@@ -5,7 +5,7 @@ class Pciutils < Formula
     sha256 "a824aca17f0b34dcc21ea46674213d0a71d213e2bb69e7314f8d8113468cb649" => :x86_64_linux
   end
 
-  url    "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.5.1.tar.xz"
+  url "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.5.1.tar.xz"
   sha256 "2bf3a4605a562fb6b8b7673bff85a474a5cf383ed7e4bd8886b4f0939013d42f"
   # tag "linuxbrew"
 

--- a/sessreg.rb
+++ b/sessreg.rb
@@ -2,7 +2,7 @@ class Sessreg < Formula
   desc "X.Org Applications: sessreg"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/sessreg-1.1.0.tar.bz2"
+  url "https://www.x.org/pub/individual/app/sessreg-1.1.0.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/sessreg-1.1.0.tar.bz2"
   sha256 "551177657835e0902b5eee7b19713035beaa1581bbd3c6506baa553e751e017c"
   # tag "linuxbrew"

--- a/setxkbmap.rb
+++ b/setxkbmap.rb
@@ -2,7 +2,7 @@ class Setxkbmap < Formula
   desc "X.Org Applications: setxkbmap"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/setxkbmap-1.3.1.tar.bz2"
+  url "https://www.x.org/pub/individual/app/setxkbmap-1.3.1.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/setxkbmap-1.3.1.tar.bz2"
   sha256 "a9ddb3963f263ba13f0ea105d8c45a531832140530217cc559587bb94f02d3e1"
   # tag "linuxbrew"

--- a/smproxy.rb
+++ b/smproxy.rb
@@ -2,7 +2,7 @@ class Smproxy < Formula
   desc "X.Org Applications: smproxy"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/smproxy-1.0.6.tar.bz2"
+  url "https://www.x.org/pub/individual/app/smproxy-1.0.6.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/smproxy-1.0.6.tar.bz2"
   sha256 "6cf19155a2752237f36dbf8bc4184465ea190d2652f887faccb4e2a6ebf77266"
   # tag "linuxbrew"

--- a/x11perf.rb
+++ b/x11perf.rb
@@ -2,7 +2,7 @@ class X11perf < Formula
   desc "X.Org Applications: x11perf"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/x11perf-1.6.0.tar.bz2"
+  url "https://www.x.org/pub/individual/app/x11perf-1.6.0.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/x11perf-1.6.0.tar.bz2"
   sha256 "e87098dec1947572d70c62697a7b70bde1ab5668237d4660080eade6bc096751"
   # tag "linuxbrew"

--- a/xauth.rb
+++ b/xauth.rb
@@ -2,7 +2,7 @@ class Xauth < Formula
   desc "X.Org Applications: xauth"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xauth-1.0.9.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xauth-1.0.9.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xauth-1.0.9.tar.bz2"
   sha256 "56ce1523eb48b1f8a4f4244fe1c3d8e6af1a3b7d4b0e6063582421b0b68dc28f"
   # tag "linuxbrew"

--- a/xbacklight.rb
+++ b/xbacklight.rb
@@ -2,7 +2,7 @@ class Xbacklight < Formula
   desc "X.Org Applications: xbacklight"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xbacklight-1.2.1.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xbacklight-1.2.1.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xbacklight-1.2.1.tar.bz2"
   sha256 "17f6cf51a35eaa918abec36b7871d28b712c169312e22a0eaf1ffe8d6468362b"
   # tag "linuxbrew"

--- a/xcb-proto.rb
+++ b/xcb-proto.rb
@@ -1,7 +1,7 @@
 class XcbProto < Formula
   desc "XML-XCB protocol descriptions that libxcb uses for code generation"
   homepage "https://www.x.org/"
-  url    "https://xcb.freedesktop.org/dist/xcb-proto-1.12.tar.bz2"
+  url "https://xcb.freedesktop.org/dist/xcb-proto-1.12.tar.bz2"
   sha256 "5922aba4c664ab7899a29d92ea91a87aa4c1fc7eb5ee550325c3216c480a4906"
   # tag "linuxbrew"
 

--- a/xcmsdb.rb
+++ b/xcmsdb.rb
@@ -2,7 +2,7 @@ class Xcmsdb < Formula
   desc "X.Org Applications: xcmsdb"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xcmsdb-1.0.5.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xcmsdb-1.0.5.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xcmsdb-1.0.5.tar.bz2"
   sha256 "e5585361bb8b6a05bb814a8d0e444ee93e0f00180881d3070aff4571e97f67c6"
   # tag "linuxbrew"

--- a/xcursor-themes.rb
+++ b/xcursor-themes.rb
@@ -2,7 +2,7 @@ class XcursorThemes < Formula
   desc "X.Org: redglass and whiteglass animated cursor themes"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/archive/individual/data/xcursor-themes-1.0.4.tar.bz2"
+  url "https://www.x.org/archive/individual/data/xcursor-themes-1.0.4.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/data/xcursor-themes-1.0.4.tar.bz2"
   mirror "ftp://ftp.x.org/pub/individual/data/xcursor-themes-1.0.4.tar.bz2"
   sha256 "e3fd2c05b9df0d88a3d1192c02143295744685f4f9a03db116e206698331bb86"

--- a/xcursorgen.rb
+++ b/xcursorgen.rb
@@ -2,7 +2,7 @@ class Xcursorgen < Formula
   desc "X.Org Applications: xcursorgen"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xcursorgen-1.0.6.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xcursorgen-1.0.6.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xcursorgen-1.0.6.tar.bz2"
   sha256 "31c8910f54eb175a8a74a60e7662697467e21a8bf948220a6048a93924b3f66c"
   # tag "linuxbrew"

--- a/xdpyinfo.rb
+++ b/xdpyinfo.rb
@@ -2,7 +2,7 @@ class Xdpyinfo < Formula
   desc "X.Org Applications: xdpyinfo"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xdpyinfo-1.3.2.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xdpyinfo-1.3.2.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xdpyinfo-1.3.2.tar.bz2"
   sha256 "30238ed915619e06ceb41721e5f747d67320555cc38d459e954839c189ccaf51"
   # tag "linuxbrew"

--- a/xdriinfo.rb
+++ b/xdriinfo.rb
@@ -2,7 +2,7 @@ class Xdriinfo < Formula
   desc "X.Org Applications: xdriinfo"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xdriinfo-1.0.5.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xdriinfo-1.0.5.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xdriinfo-1.0.5.tar.bz2"
   sha256 "4cba3766ef89557422062287248adeb933999071bad6f3ef9c0a478a3c680119"
   # tag "linuxbrew"

--- a/xev.rb
+++ b/xev.rb
@@ -2,7 +2,7 @@ class Xev < Formula
   desc "X.Org Applications: xev"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xev-1.2.2.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xev-1.2.2.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xev-1.2.2.tar.bz2"
   sha256 "d94ae62a6c1af56c2961d71f5782076ac4116f0fa4e401420ac7e0db33dc314f"
   # tag "linuxbrew"

--- a/xf86miscproto.rb
+++ b/xf86miscproto.rb
@@ -1,7 +1,7 @@
 class Xf86miscproto < Formula
   desc "X.Org Protocol Headers: xf86miscproto"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "https://www.x.org/archive/individual/proto/xf86miscproto-0.9.3.tar.bz2"
+  url "https://www.x.org/archive/individual/proto/xf86miscproto-0.9.3.tar.bz2"
   sha256 "45b8ec6a4a8ca21066dce117e09dcc88539862e616e60fb391de05b36f63b095"
   # tag "linuxbrew"
 

--- a/xgamma.rb
+++ b/xgamma.rb
@@ -2,7 +2,7 @@ class Xgamma < Formula
   desc "X.Org Applications: xgamma"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xgamma-1.0.6.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xgamma-1.0.6.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xgamma-1.0.6.tar.bz2"
   sha256 "0ef1c35b5c18b1b22317f455c8df13c0a471a8efad63c89c98ae3ce8c2b222d3"
   # tag "linuxbrew"

--- a/xhost.rb
+++ b/xhost.rb
@@ -2,7 +2,7 @@ class Xhost < Formula
   desc "X.Org Applications: xhost"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xhost-1.0.7.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xhost-1.0.7.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xhost-1.0.7.tar.bz2"
   sha256 "93e619ee15471f576cfb30c663e18f5bc70aca577a63d2c2c03f006a7837c29a"
   # tag "linuxbrew"

--- a/xinput.rb
+++ b/xinput.rb
@@ -2,7 +2,7 @@ class Xinput < Formula
   desc "X.Org Applications: xinput"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xinput-1.6.2.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xinput-1.6.2.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xinput-1.6.2.tar.bz2"
   sha256 "3694d29b4180952fbf13c6d4e59541310cbb11eef5bf888ff3d8b7f4e3aee5c4"
   # tag "linuxbrew"

--- a/xkbcomp.rb
+++ b/xkbcomp.rb
@@ -2,7 +2,7 @@ class Xkbcomp < Formula
   desc "X.Org Applications: xkbcomp"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xkbcomp-1.4.0.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xkbcomp-1.4.0.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xkbcomp-1.4.0.tar.bz2"
   sha256 "bc69c8748c03c5ad9afdc8dff9db11994dd871b614c65f8940516da6bf61ce6b"
   # tag "linuxbrew"

--- a/xkbevd.rb
+++ b/xkbevd.rb
@@ -2,7 +2,7 @@ class Xkbevd < Formula
   desc "X.Org Applications: xkbevd"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xkbevd-1.1.4.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xkbevd-1.1.4.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xkbevd-1.1.4.tar.bz2"
   sha256 "2430a2e5302a4cb4a5530c1df8cb3721a149bbf8eb377a2898921a145197f96a"
   # tag "linuxbrew"

--- a/xkbutils.rb
+++ b/xkbutils.rb
@@ -2,7 +2,7 @@ class Xkbutils < Formula
   desc "X.Org Applications: xkbutils"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xkbutils-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xkbutils-1.0.4.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xkbutils-1.0.4.tar.bz2"
   sha256 "d2a18ab90275e8bca028773c44264d2266dab70853db4321bdbc18da75148130"
   # tag "linuxbrew"

--- a/xkill.rb
+++ b/xkill.rb
@@ -2,7 +2,7 @@ class Xkill < Formula
   desc "X.Org Applications: xkill"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xkill-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xkill-1.0.4.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xkill-1.0.4.tar.bz2"
   sha256 "88ef2a304f32f24b255e879f03c1dcd3a2be3e71d5562205414f267d919f812e"
   # tag "linuxbrew"

--- a/xlsatoms.rb
+++ b/xlsatoms.rb
@@ -2,7 +2,7 @@ class Xlsatoms < Formula
   desc "X.Org Applications: xlsatoms"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xlsatoms-1.1.2.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xlsatoms-1.1.2.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xlsatoms-1.1.2.tar.bz2"
   sha256 "47e5dc7c3dbda6db2cf8c00cedac1722835c1550aa21cfdbc9ba83906694dea4"
   # tag "linuxbrew"

--- a/xlsclients.rb
+++ b/xlsclients.rb
@@ -2,7 +2,7 @@ class Xlsclients < Formula
   desc "X.Org Applications: xlsclients"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xlsclients-1.1.3.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xlsclients-1.1.3.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xlsclients-1.1.3.tar.bz2"
   sha256 "5d9666fcc6c3de210fc70d5a841a404955af709a616fde530fe4e8f7723e3d3d"
   # tag "linuxbrew"

--- a/xmessage.rb
+++ b/xmessage.rb
@@ -2,7 +2,7 @@ class Xmessage < Formula
   desc "X.Org Applications: xmessage"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xmessage-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xmessage-1.0.4.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xmessage-1.0.4.tar.bz2"
   sha256 "bcdf4b461c439bb3ade6e1e41c47d6218b912da8e9396b7ad70856db2f95ab68"
   # tag "linuxbrew"

--- a/xmodmap.rb
+++ b/xmodmap.rb
@@ -2,7 +2,7 @@ class Xmodmap < Formula
   desc "X.Org Applications: xmodmap"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xmodmap-1.0.9.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xmodmap-1.0.9.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xmodmap-1.0.9.tar.bz2"
   sha256 "b7b0e5cc5f10d0fb6d2d6ea4f00c77e8ac0e847cc5a73be94cd86139ac4ac478"
   # tag "linuxbrew"

--- a/xorg-cf-files.rb
+++ b/xorg-cf-files.rb
@@ -2,7 +2,7 @@ class XorgCfFiles < Formula
   desc "X.Org Utilities: xorg-cf-files"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/util/xorg-cf-files-1.0.6.tar.bz2"
+  url "https://www.x.org/pub/individual/util/xorg-cf-files-1.0.6.tar.bz2"
   mirror "https://www.x.org/archive/individual/util/xorg-cf-files-1.0.6.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/util/xorg-cf-files-1.0.6.tar.bz2"
   sha256 "4dcf5a9dbe3c6ecb9d2dd05e629b3d373eae9ba12d13942df87107fdc1b3934d"

--- a/xpr.rb
+++ b/xpr.rb
@@ -2,7 +2,7 @@ class Xpr < Formula
   desc "X.Org Applications: xpr"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xpr-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xpr-1.0.4.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xpr-1.0.4.tar.bz2"
   sha256 "fed98df31eb93d3dca4688cb535aabad06be572e70ace3b1685679c18dd86cb5"
   # tag "linuxbrew"

--- a/xprop.rb
+++ b/xprop.rb
@@ -2,7 +2,7 @@ class Xprop < Formula
   desc "X.Org Applications: xprop"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xprop-1.2.2.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xprop-1.2.2.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xprop-1.2.2.tar.bz2"
   sha256 "9bee88b1025865ad121f72d32576dd3027af1446774aa8300cce3c261d869bc6"
   # tag "linuxbrew"

--- a/xrandr.rb
+++ b/xrandr.rb
@@ -2,7 +2,7 @@ class Xrandr < Formula
   desc "X.Org Applications: xrandr"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xrandr-1.5.0.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xrandr-1.5.0.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xrandr-1.5.0.tar.bz2"
   sha256 "c1cfd4e1d4d708c031d60801e527abc9b6d34b85f2ffa2cadd21f75ff38151cd"
   # tag "linuxbrew"

--- a/xrdb.rb
+++ b/xrdb.rb
@@ -2,7 +2,7 @@ class Xrdb < Formula
   desc "X.Org Applications: xrdb"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xrdb-1.1.0.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xrdb-1.1.0.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xrdb-1.1.0.tar.bz2"
   sha256 "73827b6bbfc9d27ca287d95a1224c306d7053cd7b8156641698d7dc541ca565b"
   # tag "linuxbrew"

--- a/xrefresh.rb
+++ b/xrefresh.rb
@@ -2,7 +2,7 @@ class Xrefresh < Formula
   desc "X.Org Applications: xrefresh"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xrefresh-1.0.5.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xrefresh-1.0.5.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xrefresh-1.0.5.tar.bz2"
   sha256 "3213671b0a8a9d1e8d1d5d9e3fd86842c894dd9acc1be2560eda50bc1fb791d6"
   # tag "linuxbrew"

--- a/xset.rb
+++ b/xset.rb
@@ -2,7 +2,7 @@ class Xset < Formula
   desc "X.Org Applications: xset"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xset-1.2.3.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xset-1.2.3.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xset-1.2.3.tar.bz2"
   sha256 "4382f4fb29b88647e13f3b4bc29263134270747fc159cfc5f7e3af23588c8063"
   # tag "linuxbrew"

--- a/xsetroot.rb
+++ b/xsetroot.rb
@@ -2,7 +2,7 @@ class Xsetroot < Formula
   desc "X.Org Applications: xsetroot"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xsetroot-1.1.1.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xsetroot-1.1.1.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xsetroot-1.1.1.tar.bz2"
   sha256 "ba215daaa78c415fce11b9e58c365d03bb602eaa5ea916578d76861a468cc3d9"
   # tag "linuxbrew"

--- a/xtrans.rb
+++ b/xtrans.rb
@@ -1,7 +1,7 @@
 class Xtrans < Formula
   desc "X.Org Libraries: xtrans"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url    "http://ftp.x.org/pub/individual/lib/xtrans-1.3.5.tar.bz2"
+  url "http://ftp.x.org/pub/individual/lib/xtrans-1.3.5.tar.bz2"
   sha256 "adbd3b36932ce4c062cd10f57d78a156ba98d618bdb6f50664da327502bc8301"
   # tag "linuxbrew"
 

--- a/xvinfo.rb
+++ b/xvinfo.rb
@@ -2,7 +2,7 @@ class Xvinfo < Formula
   desc "X.Org Applications: xvinfo"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xvinfo-1.1.3.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xvinfo-1.1.3.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xvinfo-1.1.3.tar.bz2"
   sha256 "9fba8b68daf53863e66d5004fa9c703fcecf69db4d151ea2d3d885d621e6e5eb"
   # tag "linuxbrew"

--- a/xwd.rb
+++ b/xwd.rb
@@ -2,7 +2,7 @@ class Xwd < Formula
   desc "X.Org Applications: xwd"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xwd-1.0.6.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xwd-1.0.6.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xwd-1.0.6.tar.bz2"
   sha256 "3bb396a2268d78de4b1c3e5237a85f7849d3434e87b3cd1f4d57eef614227d79"
   # tag "linuxbrew"

--- a/xwininfo.rb
+++ b/xwininfo.rb
@@ -2,7 +2,7 @@ class Xwininfo < Formula
   desc "X.Org Applications: xwininfo"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xwininfo-1.1.3.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xwininfo-1.1.3.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xwininfo-1.1.3.tar.bz2"
   sha256 "218eb0ea95bd8de7903dfaa26423820c523ad1598be0751d2d8b6a2c23b23ff8"
   # tag "linuxbrew"

--- a/xwud.rb
+++ b/xwud.rb
@@ -2,7 +2,7 @@ class Xwud < Formula
   desc "X.Org Applications: xwud"
   homepage "https://www.x.org/"
   ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7app.html
-  url    "https://www.x.org/pub/individual/app/xwud-1.0.4.tar.bz2"
+  url "https://www.x.org/pub/individual/app/xwud-1.0.4.tar.bz2"
   mirror "http://ftp.x.org/pub/individual/app/xwud-1.0.4.tar.bz2"
   sha256 "d6b3a09ccfe750868e26bd2384900ab5ff0d434f7f40cd272a50eda8aaa1f8bd"
   # tag "linuxbrew"


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>