### PR TITLE
Mass audit fix: use %i for arrays of symbols

### DIFF
--- a/bigreqsproto.rb
+++ b/bigreqsproto.rb
@@ -23,8 +23,8 @@ class Bigreqsproto < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
     depends_on "linuxbrew/xorg/xorg-sgml-doctools" => :build
   end
 

--- a/font-adobe-100dpi.rb
+++ b/font-adobe-100dpi.rb
@@ -20,7 +20,7 @@ class FontAdobe100dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-adobe-75dpi.rb
+++ b/font-adobe-75dpi.rb
@@ -20,7 +20,7 @@ class FontAdobe75dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-adobe-utopia-100dpi.rb
+++ b/font-adobe-utopia-100dpi.rb
@@ -20,7 +20,7 @@ class FontAdobeUtopia100dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-adobe-utopia-75dpi.rb
+++ b/font-adobe-utopia-75dpi.rb
@@ -20,7 +20,7 @@ class FontAdobeUtopia75dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-adobe-utopia-type1.rb
+++ b/font-adobe-utopia-type1.rb
@@ -20,7 +20,7 @@ class FontAdobeUtopiaType1 < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-arabic-misc.rb
+++ b/font-arabic-misc.rb
@@ -18,7 +18,7 @@ class FontArabicMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-bh-100dpi.rb
+++ b/font-bh-100dpi.rb
@@ -20,7 +20,7 @@ class FontBh100dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-bh-75dpi.rb
+++ b/font-bh-75dpi.rb
@@ -20,7 +20,7 @@ class FontBh75dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-bh-lucidatypewriter-100dpi.rb
+++ b/font-bh-lucidatypewriter-100dpi.rb
@@ -20,7 +20,7 @@ class FontBhLucidatypewriter100dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-bh-lucidatypewriter-75dpi.rb
+++ b/font-bh-lucidatypewriter-75dpi.rb
@@ -20,7 +20,7 @@ class FontBhLucidatypewriter75dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-bitstream-100dpi.rb
+++ b/font-bitstream-100dpi.rb
@@ -20,7 +20,7 @@ class FontBitstream100dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-bitstream-75dpi.rb
+++ b/font-bitstream-75dpi.rb
@@ -20,7 +20,7 @@ class FontBitstream75dpi < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-cronyx-cyrillic.rb
+++ b/font-cronyx-cyrillic.rb
@@ -20,7 +20,7 @@ class FontCronyxCyrillic < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-cursor-misc.rb
+++ b/font-cursor-misc.rb
@@ -20,7 +20,7 @@ class FontCursorMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-daewoo-misc.rb
+++ b/font-daewoo-misc.rb
@@ -20,7 +20,7 @@ class FontDaewooMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-dec-misc.rb
+++ b/font-dec-misc.rb
@@ -20,7 +20,7 @@ class FontDecMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-isas-misc.rb
+++ b/font-isas-misc.rb
@@ -20,7 +20,7 @@ class FontIsasMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-jis-misc.rb
+++ b/font-jis-misc.rb
@@ -20,7 +20,7 @@ class FontJisMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-micro-misc.rb
+++ b/font-micro-misc.rb
@@ -20,7 +20,7 @@ class FontMicroMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-misc-cyrillic.rb
+++ b/font-misc-cyrillic.rb
@@ -20,7 +20,7 @@ class FontMiscCyrillic < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-misc-misc.rb
+++ b/font-misc-misc.rb
@@ -20,7 +20,7 @@ class FontMiscMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-mutt-misc.rb
+++ b/font-mutt-misc.rb
@@ -20,7 +20,7 @@ class FontMuttMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-schumacher-misc.rb
+++ b/font-schumacher-misc.rb
@@ -20,7 +20,7 @@ class FontSchumacherMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-screen-cyrillic.rb
+++ b/font-screen-cyrillic.rb
@@ -20,7 +20,7 @@ class FontScreenCyrillic < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-sony-misc.rb
+++ b/font-sony-misc.rb
@@ -20,7 +20,7 @@ class FontSonyMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-sun-misc.rb
+++ b/font-sun-misc.rb
@@ -20,7 +20,7 @@ class FontSunMisc < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/font-winitzki-cyrillic.rb
+++ b/font-winitzki-cyrillic.rb
@@ -18,7 +18,7 @@ class FontWinitzkiCyrillic < Formula
   depends_on "linuxbrew/xorg/bdftopcf" => :build
   depends_on "linuxbrew/xorg/mkfontdir" => :build
   depends_on "fontconfig" => :build
-  depends_on "bzip2"      => [:build, :recommended]
+  depends_on "bzip2" => %i(build recommended)
 
   def install
     args = %W[

--- a/fontsproto.rb
+++ b/fontsproto.rb
@@ -23,9 +23,9 @@ class Fontsproto < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/kbproto.rb
+++ b/kbproto.rb
@@ -23,9 +23,9 @@ class Kbproto < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libice.rb
+++ b/libice.rb
@@ -28,9 +28,9 @@ class Libice < Formula
 
   if build.with?("docs") || build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop"     => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libsm.rb
+++ b/libsm.rb
@@ -27,9 +27,9 @@ class Libsm < Formula
 
   if build.with?("docs")
     depends_on "xmlto" => :build
-    depends_on "fop"     => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libx11.rb
+++ b/libx11.rb
@@ -30,10 +30,10 @@ class Libx11 < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "perl" => [:build, :optional]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "perl" => %i(build optional)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libxaw.rb
+++ b/libxaw.rb
@@ -30,9 +30,9 @@ class Libxaw < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop"     => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libxcb.rb
+++ b/libxcb.rb
@@ -22,7 +22,7 @@ class Libxcb < Formula
 
   depends_on "doxygen" => :build if build.with? "docs"
   depends_on "check" => :build if build.with? "test"
-  depends_on "libxslt" => [:build, :optional]
+  depends_on "libxslt" => %i(build optional)
 
   if build.with? "python3"
     depends_on :python3      => :build

--- a/libxdmcp.rb
+++ b/libxdmcp.rb
@@ -25,9 +25,9 @@ class Libxdmcp < Formula
 
   if build.with?("docs")
     depends_on "xmlto" => :build
-    depends_on "fop"     => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libxext.rb
+++ b/libxext.rb
@@ -27,9 +27,9 @@ class Libxext < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop"     => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libxfont.rb
+++ b/libxfont.rb
@@ -37,7 +37,7 @@ class Libxfont < Formula
 
     depends_on "xmlto" => :build
     depends_on "fop" => :build
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libxfont2.rb
+++ b/libxfont2.rb
@@ -36,7 +36,7 @@ class Libxfont2 < Formula
 
     depends_on "xmlto" => :build
     depends_on "fop" => :build
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libxi.rb
+++ b/libxi.rb
@@ -32,10 +32,10 @@ class Libxi < Formula
     end
 
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "asciidoc" => [:build, :optional]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "asciidoc" => %i(build optional)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libxmu.rb
+++ b/libxmu.rb
@@ -29,9 +29,9 @@ class Libxmu < Formula
 
   if build.with?("docs")
     depends_on "xmlto" => :build
-    depends_on "fop"     => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/libxt.rb
+++ b/libxt.rb
@@ -31,10 +31,10 @@ class Libxt < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop"     => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "perl"    => [:build, :optional]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "perl" => %i(build optional)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   if build.with?("glib")

--- a/libxtst.rb
+++ b/libxtst.rb
@@ -26,9 +26,9 @@ class Libxtst < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/recordproto.rb
+++ b/recordproto.rb
@@ -23,9 +23,9 @@ class Recordproto < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/scrnsaverproto.rb
+++ b/scrnsaverproto.rb
@@ -23,9 +23,9 @@ class Scrnsaverproto < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/xcmiscproto.rb
+++ b/xcmiscproto.rb
@@ -23,9 +23,9 @@ class Xcmiscproto < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/xextproto.rb
+++ b/xextproto.rb
@@ -23,9 +23,9 @@ class Xextproto < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/xorg-docs.rb
+++ b/xorg-docs.rb
@@ -16,10 +16,10 @@ class XorgDocs < Formula
   option "without-specs", "Do not build specifications"
   option "without-test", "Skip compile-time testsation"
 
-  depends_on "linuxbrew/xorg/util-macros" => [:build, :recommended]
+  depends_on "linuxbrew/xorg/util-macros" => %i(build recommended)
   depends_on "xmlto" => :build
-  depends_on "fop"         => [:build, :recommended]
-  depends_on "libxslt"     => [:build, :recommended]
+  depends_on "fop" => %i(build recommended)
+  depends_on "libxslt" => %i(build recommended)
   depends_on "linuxbrew/xorg/xorg-sgml-doctools" => :build
   depends_on "docbook" => :build
   depends_on "docbook-xsl" => :build

--- a/xproto.rb
+++ b/xproto.rb
@@ -23,9 +23,9 @@ class Xproto < Formula
 
   if build.with?("specs")
     depends_on "xmlto" => :build
-    depends_on "fop" => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install

--- a/xtrans.rb
+++ b/xtrans.rb
@@ -22,9 +22,9 @@ class Xtrans < Formula
 
   if build.with?("docs")
     depends_on "xmlto" => :build
-    depends_on "fop"     => [:build, :recommended]
-    depends_on "libxslt" => [:build, :recommended]
-    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => [:build, :recommended]
+    depends_on "fop" => %i(build recommended)
+    depends_on "libxslt" => %i(build recommended)
+    depends_on "linuxbrew/xorg/xorg-sgml-doctools" => %i(build recommended)
   end
 
   def install


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

For clarity:

```ruby
%i(build recommended) == [:build, :recommended]
# => true
```

These were failing audits left and right.

Note that I still have yet to fix the HTTPS URL's for a lot of these formulae; I'll try to do that after #306 is merged, because it would introduce a lot of merge conflicts, which I'd prefer to avoid.