### PR TITLE
mesa: Update patch URL

### DIFF
--- a/mesa.rb
+++ b/mesa.rb
@@ -51,7 +51,7 @@ class Mesa < Formula
   end
 
   patch :p1 do
-    url "http://www.linuxfromscratch.org/patches/blfs/svn/mesa-17.0.0-add_xdemos-1.patch"
+    url "http://www.linuxfromscratch.org/patches/blfs/svn/mesa-17.1.2-add_xdemos-1.patch"
     sha256 "53492ca476e3df2de210f749983e17de4bec026a904db826acbcbd1ef83e71cd"
   end
 


### PR DESCRIPTION
The old patch was apparently deleted and reuploaded with a new filename.
The patch contents are the same.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

```
==> Downloading http://www.linuxfromscratch.org/patches/blfs/svn/mesa-17.0.0-add_xdemos-1.patch
/home/linuxbrew/.linuxbrew/opt/curl/bin/curl --remote-time --location --user-agent Linuxbrew/1.2.0-94-g2e121544f (Linux; x86_64 Ubuntu 17.04) curl/7.54.1 --fail http://www.linuxfromscratch.org/patches/blfs/svn/mesa-17.0.0-add_xdemos-1.patch -C 0 -o /home/bob/.cache/Homebrew/mesa--patch-53492ca476e3df2de210f749983e17de4bec026a904db826acbcbd1ef83e71cd.patch.incomplete
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "mesa--patch"
Download failed: http://www.linuxfromscratch.org/patches/blfs/svn/mesa-17.0.0-add_xdemos-1.patch
```