### PR TITLE
pciutils: Fix audit

### DIFF
--- a/pciutils.rb
+++ b/pciutils.rb
@@ -1,13 +1,13 @@
 class Pciutils < Formula
   desc "Programs for inspecting and manipulating configuration of PCI devices"
   homepage "https://www.x.org/"
-  bottle do
-    sha256 "a824aca17f0b34dcc21ea46674213d0a71d213e2bb69e7314f8d8113468cb649" => :x86_64_linux
-  end
-
   url "https://www.kernel.org/pub/software/utils/pciutils/pciutils-3.5.1.tar.xz"
   sha256 "2bf3a4605a562fb6b8b7673bff85a474a5cf383ed7e4bd8886b4f0939013d42f"
   # tag "linuxbrew"
+
+  bottle do
+    sha256 "a824aca17f0b34dcc21ea46674213d0a71d213e2bb69e7314f8d8113468cb649" => :x86_64_linux
+  end
 
   depends_on "pkg-config" => :build
 


### PR DESCRIPTION
Move the bottle block below the url and such.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?