### PR TITLE
Font Formulae: Use lowercase letters in keg_only reasons

### DIFF
--- a/encodings.rb
+++ b/encodings.rb
@@ -14,7 +14,7 @@ class Encodings < Formula
     sha256 "80e9c0aea351de9f225610fb98692d95b6cdaa4d0800592b96cb9bfa5ebe5449" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-adobe-100dpi.rb
+++ b/font-adobe-100dpi.rb
@@ -13,7 +13,7 @@ class FontAdobe100dpi < Formula
     sha256 "9449470dfe1eab078e115c9cc75fc1b727f8d295373dddd43deb193b7dafeffe" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-adobe-75dpi.rb
+++ b/font-adobe-75dpi.rb
@@ -13,7 +13,7 @@ class FontAdobe75dpi < Formula
     sha256 "5fb855142edaad70987a116a51fa8bc7e07c1b1044e9c3906e0784a123de0e05" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-adobe-utopia-100dpi.rb
+++ b/font-adobe-utopia-100dpi.rb
@@ -13,7 +13,7 @@ class FontAdobeUtopia100dpi < Formula
     sha256 "3d01428b722e9f7e9212957ee6bcce9c7d890fe118f8b483f43370728cead900" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-adobe-utopia-75dpi.rb
+++ b/font-adobe-utopia-75dpi.rb
@@ -13,7 +13,7 @@ class FontAdobeUtopia75dpi < Formula
     sha256 "293b881efa2650c70d603725b62beef60a99c15037617b5666622267d111fada" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-adobe-utopia-type1.rb
+++ b/font-adobe-utopia-type1.rb
@@ -13,7 +13,7 @@ class FontAdobeUtopiaType1 < Formula
     sha256 "492fa5bec414041c77b6fec828a58490bd8a95955eb8b0963f45adf85d364af3" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bh-100dpi.rb
+++ b/font-bh-100dpi.rb
@@ -13,7 +13,7 @@ class FontBh100dpi < Formula
     sha256 "3c54560deb82bf754a7ea1cb500a105a021fe7ffc9ec049fc89839a2f28a4b3b" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bh-75dpi.rb
+++ b/font-bh-75dpi.rb
@@ -13,7 +13,7 @@ class FontBh75dpi < Formula
     sha256 "608037ec9689715468ff01fcbc2c3489643967b61ed55caf05a10c59ab20515e" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bh-lucidatypewriter-100dpi.rb
+++ b/font-bh-lucidatypewriter-100dpi.rb
@@ -13,7 +13,7 @@ class FontBhLucidatypewriter100dpi < Formula
     sha256 "1acd5d3c7eb230a2cf8fe4d125522f3893cbb4691eb5d31740965135a3a9e564" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bh-lucidatypewriter-75dpi.rb
+++ b/font-bh-lucidatypewriter-75dpi.rb
@@ -13,7 +13,7 @@ class FontBhLucidatypewriter75dpi < Formula
     sha256 "eeb6ffdb0265b5e081fe3e9efd256b0c93e9f7795745c68853ee391432736fba" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bh-ttf.rb
+++ b/font-bh-ttf.rb
@@ -13,7 +13,7 @@ class FontBhTtf < Formula
     sha256 "0a24a4cfb38a8c3350a99c4da06e4e42267dd8770e50c628408acb8e60ee70e0" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bh-type1.rb
+++ b/font-bh-type1.rb
@@ -13,7 +13,7 @@ class FontBhType1 < Formula
     sha256 "f2661f4b46de64ac5cbeb5de96a4b520e02b9a6c49fb05d340d96d571d5479d8" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bitstream-100dpi.rb
+++ b/font-bitstream-100dpi.rb
@@ -13,7 +13,7 @@ class FontBitstream100dpi < Formula
     sha256 "66942e76d5ab2d02928f237b9d5014aa6ea441c92ce2344736f10f2a4ddb4ba5" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bitstream-75dpi.rb
+++ b/font-bitstream-75dpi.rb
@@ -13,7 +13,7 @@ class FontBitstream75dpi < Formula
     sha256 "4da5e621aee2faf3622f5e431dbf66ee5492a3035fa11e62b6da421d764e3e8a" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-bitstream-type1.rb
+++ b/font-bitstream-type1.rb
@@ -13,7 +13,7 @@ class FontBitstreamType1 < Formula
     sha256 "dba686a6a51936e06bcb7de93d3f2f2d6f3b1b7bfe52c7eb0c75758d8a41c84a" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-cronyx-cyrillic.rb
+++ b/font-cronyx-cyrillic.rb
@@ -13,7 +13,7 @@ class FontCronyxCyrillic < Formula
     sha256 "94fd339a7f2858e59f0e21c1db0e376ef738f906e6c7175f3dc1defae58bd6d9" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-cursor-misc.rb
+++ b/font-cursor-misc.rb
@@ -13,7 +13,7 @@ class FontCursorMisc < Formula
     sha256 "467daf5b42875a9ea59e6cac6920c9bf3a6218e728b3de1fb753fd4a0fab49e9" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-daewoo-misc.rb
+++ b/font-daewoo-misc.rb
@@ -13,7 +13,7 @@ class FontDaewooMisc < Formula
     sha256 "82befe88a91fda095936f91e2592ff62ec213e8bcdc716d23ce49869a63915b6" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-dec-misc.rb
+++ b/font-dec-misc.rb
@@ -13,7 +13,7 @@ class FontDecMisc < Formula
     sha256 "89218bea462ffd7dbdd4d81642856d8c768ff729eec26d8188a60cd791f80185" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-ibm-type1.rb
+++ b/font-ibm-type1.rb
@@ -13,7 +13,7 @@ class FontIbmType1 < Formula
     sha256 "e5557df70a617f487529147dd44834abcc8ee20e364f9ff558adcb0ec38b40b2" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-isas-misc.rb
+++ b/font-isas-misc.rb
@@ -13,7 +13,7 @@ class FontIsasMisc < Formula
     sha256 "de25e41ac6c7efeef6acd0169d35b1a8ca688d684ca5ac4daa58ac21b3392bdc" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-jis-misc.rb
+++ b/font-jis-misc.rb
@@ -13,7 +13,7 @@ class FontJisMisc < Formula
     sha256 "c2f51db2f65e98ed6b50d3b79152722e4c1ff49f47da79db51a3593bb513cbdc" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-micro-misc.rb
+++ b/font-micro-misc.rb
@@ -13,7 +13,7 @@ class FontMicroMisc < Formula
     sha256 "6ed219758dbdd467c430fcd746bf1c4380144fd605710a14032c284ad247d169" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-misc-cyrillic.rb
+++ b/font-misc-cyrillic.rb
@@ -13,7 +13,7 @@ class FontMiscCyrillic < Formula
     sha256 "f6fa4203c01fc448ceda1a1628303f5269213ceebbbdf10b3660571034b6886e" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-misc-ethiopic.rb
+++ b/font-misc-ethiopic.rb
@@ -13,7 +13,7 @@ class FontMiscEthiopic < Formula
     sha256 "0d5247e5301246e6d86f50d73901d952d76bc58f9e88973340d61d6d51530557" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-misc-meltho.rb
+++ b/font-misc-meltho.rb
@@ -13,7 +13,7 @@ class FontMiscMeltho < Formula
     sha256 "fde87b8065adb016d78cf6b9b16fa4eface5109cc75269a3008135dfe4ad991d" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-misc-misc.rb
+++ b/font-misc-misc.rb
@@ -13,7 +13,7 @@ class FontMiscMisc < Formula
     sha256 "bf3f1917f6e6f3c944d88b68e356c48206349c477a4d2fde5758587d3c1d8f16" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-mutt-misc.rb
+++ b/font-mutt-misc.rb
@@ -13,7 +13,7 @@ class FontMuttMisc < Formula
     sha256 "6375fb662f3f8892cceb5e82779a74038479816fce9fd44920c72804248a366c" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-schumacher-misc.rb
+++ b/font-schumacher-misc.rb
@@ -13,7 +13,7 @@ class FontSchumacherMisc < Formula
     sha256 "557113547fe9582e11ffa7c55275ea79ef2e764cd9e7502f208c3c30ff8543d2" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-screen-cyrillic.rb
+++ b/font-screen-cyrillic.rb
@@ -13,7 +13,7 @@ class FontScreenCyrillic < Formula
     sha256 "5104d13989ec22da09421c9ff80d9c2251e0687aff60fa1eac6ebe6d8fc20456" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-sony-misc.rb
+++ b/font-sony-misc.rb
@@ -13,7 +13,7 @@ class FontSonyMisc < Formula
     sha256 "0c25b9c97a94670867c137b1c1f03beb5f458bb4df8c2fb2d475a9677e16b08d" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-sun-misc.rb
+++ b/font-sun-misc.rb
@@ -13,7 +13,7 @@ class FontSunMisc < Formula
     sha256 "c516e800165641ab852931d59a63d01cf2ce411fc6bdbac362bb06edf83ca855" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build

--- a/font-xfree86-type1.rb
+++ b/font-xfree86-type1.rb
@@ -14,7 +14,7 @@ class FontXfree86Type1 < Formula
     sha256 "9b233d97e93dda17c3ab99cad08ee76346a92baef99af21655ee5b39007f33fc" => :x86_64_linux
   end
 
-  keg_only "Part of Xorg-fonts package"
+  keg_only "part of Xorg-fonts package"
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/font-util" => :build


### PR DESCRIPTION
Fixes the audit message: `'Part' from the keg_only reason should be 'part'.`

# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
