### PR TITLE
libglvnd: Remove formula name from desc

### DIFF
--- a/libglvnd.rb
+++ b/libglvnd.rb
@@ -1,5 +1,5 @@
 class Libglvnd < Formula
-  desc "libglvnd: GL Vendor-Neutral Dispatch library"
+  desc "GL Vendor-Neutral Dispatch library"
   homepage "https://github.com/NVIDIA/libglvnd"
 
   url "https://github.com/NVIDIA/libglvnd.git"


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
