### PR TITLE
libxtst: Use https for URL

### DIFF
--- a/libxtst.rb
+++ b/libxtst.rb
@@ -1,7 +1,8 @@
 class Libxtst < Formula
   desc "X.Org Libraries: libXtst"
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
-  url "http://ftp.x.org/pub/individual/lib/libXtst-1.2.3.tar.bz2"
+  url "https://ftp.x.org/pub/individual/lib/libXtst-1.2.3.tar.bz2"
+  mirror "ftp://ftp.x.org/pub/individual/lib/libXtst-1.2.3.tar.bz2"
   sha256 "4655498a1b8e844e3d6f21f3b2c4e2b571effb5fd83199d428a6ba7ea4bf5204"
   # tag "linuxbrew"
 


### PR DESCRIPTION
Also add a mirror.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

