### PR TITLE
.github/CONTRIBUTING.md: Fix link to brew contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing to homebrew-xorg
-Please follow the [general Linuxbrew contribution guidelines](https://github.com/linuxbrew/brew/blob/master/.github/CONTRIBUTING.md).
+Please follow the [general Linuxbrew contribution guidelines](https://github.com/linuxbrew/brew/blob/master/CONTRIBUTING.md).
 
 Thanks!


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

# Contributing to homebrew-xorg:
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?