### PR TITLE
CircleCI: Disable analytics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_VERBOSE: 1
       HOMEBREW_VERBOSE_USING_DOTS: 1
+      HOMEBREW_NO_ANALYTICS: 1
     steps:
       - run:
           name: Set up Git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ jobs:
       - image: linuxbrew/linuxbrew
     environment:
       HOMEBREW_DEVELOPER: 1
+      HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_VERBOSE: 1
       HOMEBREW_VERBOSE_USING_DOTS: 1
-      HOMEBREW_NO_ANALYTICS: 1
     steps:
       - run:
           name: Set up Git


### PR DESCRIPTION
I don't think we want Homebrew analytics tracking our failing builds on CircleCI :trollface: 