### PR TITLE
Convert proto deps to build-time deps

### DIFF
--- a/Formula/libvdpau.rb
+++ b/Formula/libvdpau.rb
@@ -15,7 +15,7 @@ class Libvdpau < Formula
   depends_on "pkg-config" => :build
 
   # Required
-  depends_on "linuxbrew/xorg/dri2proto"
+  depends_on "linuxbrew/xorg/dri2proto" => :build
   depends_on "linuxbrew/xorg/libxext"
   depends_on "linuxbrew/xorg/libx11"
 

--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -23,7 +23,7 @@ class Libxcb < Formula
   depends_on "doxygen" => :build if build.with? "docs"
   depends_on "check" => :build if build.with? "test"
   depends_on "libxslt" => [:build, :optional]
-  depends_on "python@2" => [:build] unless which "python2.7"
+  depends_on "python@2" => :build unless which "python2.7"
 
   patch :p1 do
     url "https://cgit.freedesktop.org/xcb/libxcb/patch/?id=8740a288ca468433141341347aa115b9544891d3"

--- a/Formula/libxfont.rb
+++ b/Formula/libxfont.rb
@@ -19,9 +19,9 @@ class Libxfont < Formula
   option "with-brewed-bzip2", "Use libbz2 to support bzip2 compressed bitmap fonts"
 
   depends_on "pkg-config" => :build
-  depends_on "linuxbrew/xorg/xproto"
+  depends_on "linuxbrew/xorg/xproto" => :build
   depends_on "linuxbrew/xorg/xtrans" => :build
-  depends_on "linuxbrew/xorg/fontsproto"
+  depends_on "linuxbrew/xorg/fontsproto" => :build
   depends_on "linuxbrew/xorg/libfontenc"
   depends_on "freetype"
 

--- a/Formula/libxfont2.rb
+++ b/Formula/libxfont2.rb
@@ -18,9 +18,9 @@ class Libxfont2 < Formula
   option "with-brewed-bzip2", "Use libbz2 to support bzip2 compressed bitmap fonts"
 
   depends_on "pkg-config" => :build
-  depends_on "linuxbrew/xorg/xproto"
+  depends_on "linuxbrew/xorg/xproto" => :build
   depends_on "linuxbrew/xorg/xtrans" => :build
-  depends_on "linuxbrew/xorg/fontsproto"
+  depends_on "linuxbrew/xorg/fontsproto" => :build
   depends_on "linuxbrew/xorg/libfontenc"
   depends_on "freetype"
 

--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -16,7 +16,7 @@ class XcbProto < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libxml2" => :build if build.with? "test"
-  depends_on "python@2" => [:build] unless which "python2.7"
+  depends_on "python@2" => :build unless which "python2.7"
 
   patch :p1 do
     url "http://www.linuxfromscratch.org/patches/blfs/svn/xcb-proto-1.12-python3-1.patch"

--- a/Formula/xdriinfo.rb
+++ b/Formula/xdriinfo.rb
@@ -9,7 +9,7 @@ class Xdriinfo < Formula
 
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/libx11"
-  depends_on "linuxbrew/xorg/glproto"
+  depends_on "linuxbrew/xorg/glproto" => :build
   depends_on "linuxbrew/xorg/mesa"
 
   def install


### PR DESCRIPTION
All `*-proto` packages are supposed to be build-time dependencies... But it is not the case as of now. Fixing this here.