### PR TITLE
libxau: xorg-protocols are build-time dependency

### DIFF
--- a/Formula/libxau.rb
+++ b/Formula/libxau.rb
@@ -14,7 +14,7 @@ class Libxau < Formula
   option "with-static", "Build static libraries (not recommended)"
 
   depends_on "pkg-config" => :build
-  depends_on "linuxbrew/xorg/xorg-protocols"
+  depends_on "linuxbrew/xorg/xorg-protocols" => :build
 
   def install
     args = %W[


### PR DESCRIPTION
In `libxau`, `xorg-protocols` somehow were not a build-time dependency... Whooops!