### PR TITLE
libxau: depend on xproto instead of xorg-protocols

### DIFF
--- a/Formula/libxau.rb
+++ b/Formula/libxau.rb
@@ -14,7 +14,7 @@ class Libxau < Formula
   option "with-static", "Build static libraries (not recommended)"
 
   depends_on "pkg-config" => :build
-  depends_on "linuxbrew/xorg/xorg-protocols" => :build
+  depends_on "linuxbrew/xorg/xproto"
 
   def install
     args = %W[


### PR DESCRIPTION
`libxau` shoould depend on a specific package (`xproto`) and not on a meta-package (`xorg-protocols`). The reason is that when a specific component of `xorg-protocols` is uninstalled, Homebrew/Linuxbrew still considers `xorg-protocols` to be installed.