### PR TITLE
libxdmcp: depend on xproto instead of xorg-protocols

### DIFF
--- a/Formula/libxdmcp.rb
+++ b/Formula/libxdmcp.rb
@@ -15,7 +15,7 @@ class Libxdmcp < Formula
   option "with-docs", "Build documentation"
 
   depends_on "pkg-config" => :build
-  depends_on "linuxbrew/xorg/xorg-protocols" => :build
+  depends_on "linuxbrew/xorg/xproto"
 
   # Patch for xmlto
   patch do


### PR DESCRIPTION
`libxdmcp` should depend on a specific package (`xproto`) and not on a meta-package (`xorg-protocols`). The reason is that when a specific component of `xorg-protocols` is uninstalled, Homebrew/Linuxbrew still considers `xorg-protocols` to be installed.