### PR TITLE
libomxil-bellagio: autoreconf should be removed

### DIFF
--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -26,6 +26,7 @@ class LibomxilBellagio < Formula
 
     # Be explicit about the configure flags
     args << "--enable-static=#{build.with?("static") ? "yes" : "no"}"
+    
     system "./configure", *args
     ENV.deparallelize
     ENV.delete "CFLAGS"

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -32,6 +32,6 @@ class LibomxilBellagio < Formula
     ENV.deparallelize
     system "make CFLAGS="
     system "make", "install"
-    system "make CFLAGS=", "check" if build.with?("test")
+    system "make", "check CFLAGS=" if build.with?("test")
   end
 end

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -29,8 +29,8 @@ class LibomxilBellagio < Formula
     
     system "./configure", *args
     ENV.deparallelize
-    system "make CFLAGS="
+    system "make", "CFLAGS="
     system "make", "install"
-    system "make", "check CFLAGS=" if build.with?("test")
+    system "make", "check", "CFLAGS=" if build.with? "test"
   end
 end

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -30,8 +30,8 @@ class LibomxilBellagio < Formula
     #system "autoreconf", "-fiv"
     system "./configure", *args
     ENV.deparallelize
-    system "make CFLAGS="
+    system "CFLAGS='' make"
     system "make", "install"
-    system "make", "check CFLAGS=" if build.with?("test")
+    system "CFLAGS='' make", "check" if build.with?("test")
   end
 end

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -30,7 +30,6 @@ class LibomxilBellagio < Formula
     
     system "./configure", *args
     ENV.deparallelize
-
     system "make"
     system "make", "install"
     system "make", "check" if build.with?("test")

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -26,12 +26,11 @@ class LibomxilBellagio < Formula
 
     # Be explicit about the configure flags
     args << "--enable-static=#{build.with?("static") ? "yes" : "no"}"
-
-    #system "autoreconf", "-fiv"
     system "./configure", *args
     ENV.deparallelize
-    system "CFLAGS='' make"
+    ENV.delete "CFLAGS"
+    system "make"
     system "make", "install"
-    system "CFLAGS='' make", "check" if build.with?("test")
+    system "make", "check" if build.with?("test")
   end
 end

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -17,6 +17,7 @@ class LibomxilBellagio < Formula
   depends_on "libtool" => :build
 
   def install
+    ENV.delete "CFLAGS"
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}
@@ -29,7 +30,7 @@ class LibomxilBellagio < Formula
     
     system "./configure", *args
     ENV.deparallelize
-    ENV.delete "CFLAGS"
+
     system "make"
     system "make", "install"
     system "make", "check" if build.with?("test")

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -17,7 +17,6 @@ class LibomxilBellagio < Formula
   depends_on "libtool" => :build
 
   def install
-    ENV.delete "CFLAGS"
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}
@@ -30,8 +29,8 @@ class LibomxilBellagio < Formula
     
     system "./configure", *args
     ENV.deparallelize
-    system "make"
+    system "make CFLAGS="
     system "make", "install"
-    system "make", "check" if build.with?("test")
+    system "make", "check CFLAGS=" if build.with?("test")
   end
 end

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -27,11 +27,11 @@ class LibomxilBellagio < Formula
     # Be explicit about the configure flags
     args << "--enable-static=#{build.with?("static") ? "yes" : "no"}"
 
-    system "autoreconf", "-fiv"
+    #system "autoreconf", "-fiv"
     system "./configure", *args
     ENV.deparallelize
-    system "make"
+    system "make CFLAGS="
     system "make", "install"
-    system "make", "check" if build.with?("test")
+    system "make CFLAGS=", "check" if build.with?("test")
   end
 end


### PR DESCRIPTION
Should autoreconf be needed? CentOS doesn't need it.
And -Wall -Werror is removed.

# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?

