### PR TITLE
mesa: Add option of "without-gpu"

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -114,13 +114,13 @@ class Mesa < Formula
 
     if build.with? "gpu"
       args += %W[
-        --with-egl-platforms=drm,x11,surfaceless#{build.with?("wayland") ? ",wayland" : ""}
+        --with-platforms=drm,x11,surfaceless#{build.with?("wayland") ? ",wayland" : ""}
         --with-gallium-drivers=i915,nouveau,r300,r600,radeonsi,svga,swrast,swr
         --with-dri-drivers=i965,nouveau,radeon,r200,swrast
       ]
     else
       args += %W[
-        --with-egl-platforms=
+        --with-platforms=
         --with-gallium-drivers=swrast,swr
         --with-dri-drivers=
       ]

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -3,7 +3,7 @@ class Mesa < Formula
   homepage "https://dri.freedesktop.org"
   url "https://mesa.freedesktop.org/archive/mesa-17.2.3.tar.xz"
   sha256 "a0b0ec8f7b24dd044d7ab30a8c7e6d3767521e245f88d4ed5dd93315dc56f837"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -13,6 +13,7 @@ class Mesa < Formula
 
   option "without-test", "Skip compile-time tests"
   option "with-static", "Build static libraries (not recommended)"
+  option "without-gpu", "Build without graphics hardware"
 
   depends_on "pkg-config" => :build
   depends_on "python" => :build
@@ -77,6 +78,9 @@ class Mesa < Formula
       system "python", *Language::Python.setup_install_args(libexec/"vendor")
     end
 
+    gpu = build.with?("gpu") ? "yes" : "no"
+    nogpu = build.with?("gpu") ? "no" : "yes"
+
     args = %W[
       CFLAGS=#{ENV.cflags}
       CXXFLAGS=#{ENV.cflags}
@@ -85,31 +89,47 @@ class Mesa < Formula
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --enable-texture-float
-      --enable-gles1
-      --enable-gles2
-      --enable-osmesa
-      --enable-xa
-      --enable-gbm
-      --with-egl-platforms=drm,x11,surfaceless#{build.with?("wayland") ? ",wayland" : ""}
-      --with-gallium-drivers=i915,nouveau,r300,r600,radeonsi,svga,swrast,swr
-      --enable-glx-tls
-      --enable-dri
-      --enable-dri3
-      --enable-gallium-tests
-      --enable-glx
       --enable-opengl
-      --enable-shared-glapi
-      --enable-va
-      --enable-vdpau
-      --enable-xvmc
-      --disable-llvm-shared-libs
-      --with-dri-drivers=i965,nouveau,radeon,r200,swrast
       --with-sha1=libsha1
       --enable-llvm
-      --enable-sysfs
+      --disable-llvm-shared-libs
+      --enable-shared-glapi
       --with-llvm-prefix=#{Formula["llvm@4"].opt_prefix}
+      --enable-dri3=#{gpu}
+      --enable-dri=#{gpu}
+      --enable-egl=#{gpu}
+      --enable-gallium-osmesa=#{nogpu}
+      --enable-gallium-tests=#{gpu}
+      --enable-gbm=#{gpu}
+      --enable-gles1=#{gpu}
+      --enable-gles2=#{gpu}
+      --enable-glx-tls=#{gpu}
+      --enable-glx=#{gpu}
+      --enable-osmesa=#{gpu}
+      --enable-sysfs=#{gpu}
+      --enable-texture-float=#{gpu}
+      --enable-va=#{gpu}
+      --enable-vdpau=#{gpu}
+      --enable-xa=#{gpu}
+      --enable-xvmc=#{gpu}
     ]
+
+    if build.with? "gpu"
+      args += %W[
+        --with-egl-platforms=drm,x11,surfaceless#{build.with?("wayland") ? ",wayland" : ""}
+        --with-gallium-drivers=i915,nouveau,r300,r600,radeonsi,svga,swrast,swr
+        --with-dri-drivers=i965,nouveau,radeon,r200,swrast
+      ]
+    else
+      args += %W[
+        --with-egl-platforms=
+        --with-gallium-drivers=swrast,swr
+        --with-dri-drivers=
+      ]
+    end
+
+    # Possible gallium drivers:
+    # ddebug,etnaviv,freedreno,i915,imx,llvmpipe,noop,nouveau,pl111,r300,r600,radeon,radeonsi,rbug,softpipe,svga,swr,trace,vc4,virgl
 
     # enable-opencl => needs libclc
     # enable-gallium-osmesa => mutually exclusive with enable-osmesa
@@ -121,10 +141,10 @@ class Mesa < Formula
 
     system "./autogen.sh", *args
     system "make"
-    system "make", "-C", "xdemos", "DEMOS_PREFIX=#{prefix}"
+    system "make", "-C", "xdemos", "DEMOS_PREFIX=#{prefix}" if build.with? "gpu"
     system "make", "check" if build.with?("test")
     system "make", "install"
-    system "make", "-C", "xdemos", "DEMOS_PREFIX=#{prefix}", "install"
+    system "make", "-C", "xdemos", "DEMOS_PREFIX=#{prefix}", "install" if build.with? "gpu"
 
     if build.with?("libva")
       resource("libva").stage do
@@ -201,3 +221,4 @@ class Mesa < Formula
     end
   end
 end
+

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -32,7 +32,6 @@ class Mesa < Formula
 
   depends_on "linuxbrew/xorg/libdrm"
   depends_on "systemd" # provides libudev <= needed by "gbm"
-  depends_on "linuxbrew/xorg/libsha1"
   depends_on "llvm@4" # failed with llvm@6
   depends_on "libelf" # radeonsi requires libelf when using llvm
   depends_on "linuxbrew/xorg/libomxil-bellagio"
@@ -90,7 +89,6 @@ class Mesa < Formula
       --sysconfdir=#{etc}
       --localstatedir=#{var}
       --enable-opengl
-      --with-sha1=libsha1
       --enable-llvm
       --disable-llvm-shared-libs
       --enable-shared-glapi


### PR DESCRIPTION
For the system without graphic driver, I would like to add an option "with-only-cpu".

# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

