### PR TITLE
Xtrans sys/stropts.h fix for Fedora

### DIFF
--- a/Formula/xtrans.rb
+++ b/Formula/xtrans.rb
@@ -6,11 +6,6 @@ class Xtrans < Formula
   revision 1
   # tag "linuxbrew"
 
-  bottle do
-    cellar :any
-    sha256 "90e5852ee25ed85ba47acaa55723a0506c8313c599671b892024ac1766b15449" => :x86_64_linux
-  end
-
   option "with-docs", "Build documentation"
 
   depends_on "linuxbrew/xorg/util-macros" => :build

--- a/Formula/xtrans.rb
+++ b/Formula/xtrans.rb
@@ -3,6 +3,7 @@ class Xtrans < Formula
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
   url "https://ftp.x.org/pub/individual/lib/xtrans-1.3.5.tar.bz2"
   sha256 "adbd3b36932ce4c062cd10f57d78a156ba98d618bdb6f50664da327502bc8301"
+  revision 1
   # tag "linuxbrew"
 
   bottle do
@@ -37,6 +38,9 @@ class Xtrans < Formula
       --disable-silent-rules
       --enable-docs=#{build.with?("docs") ? "yes" : "no"}
     ]
+
+    # Fedora systems do not provide sys/stropts.h
+    inreplace "Xtranslcl.c", "# include <sys/stropts.h>", "# include <sys/ioctl.h>"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
- [x] Ensure that libx11 compiles successfully
- [ ] Clean commit history
- [x] Only apply patch for Fedora