### PR TITLE
xcb: Simplify dependency tree

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,6 @@ jobs:
       HOMEBREW_VERBOSE_USING_DOTS: 1
     steps:
       - run:
-          name: Install minimal python for libxcb build
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends python2.7-minimal
-      - run:
           name: Set up Git
           command: |
             git config --global user.name LinuxbrewTestBot

--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -3,12 +3,12 @@ class Libxcb < Formula
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
   url "https://xcb.freedesktop.org/dist/libxcb-1.13.1.tar.bz2"
   sha256 "a89fb7af7a11f43d2ce84a844a4b38df688c092bf4b67683aef179cdf2a647c4"
+  revision 1
   # tag "linuxbrew"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
-    sha256 "657c38f163f14bc65729f6b15414da87d896adc3d005642289bd9d4c0544b05f" => :x86_64_linux
   end
 
   option "without-test", "Skip compile-time tests"
@@ -17,7 +17,6 @@ class Libxcb < Formula
 
   depends_on "linuxbrew/xorg/xcb-proto" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
   depends_on "linuxbrew/xorg/libpthread-stubs" # xcb.pc references pthread-stubs
   depends_on "linuxbrew/xorg/libxau"
   depends_on "linuxbrew/xorg/libxdmcp"
@@ -25,11 +24,6 @@ class Libxcb < Formula
   if build.with? "devel-docs"
     depends_on "doxygen" => :build
     depends_on "graphviz" => :build
-  end
-
-  if build.with? "test"
-    depends_on "check" => :build
-    depends_on "libxslt" => [:build, :recommended]
   end
 
   def install
@@ -53,7 +47,6 @@ class Libxcb < Formula
 
     system "./configure", *args
     system "make"
-    system "make", "check" if build.with? "test"
     system "make", "install"
   end
 end

--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -3,21 +3,18 @@ class XcbProto < Formula
   homepage "https://www.x.org/"
   url "https://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.bz2"
   sha256 "7b98721e669be80284e9bbfeab02d2d0d54cd11172b72271e47a2fe875e2bde1"
+  revision 1
   # tag "linuxbrew"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
-    sha256 "68f456b5eeeb486d33019d410ab25acc3cdc8fb10240c4c08f3b59d4e5bf5d1e" => :x86_64_linux
   end
 
-  option "without-test", "Skip compile-time tests"
-  option "with-python@2", "Build with Python 2"
-
-  depends_on "libxml2" => :build if build.with? "test"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build if build.without? "python@2"
-  depends_on "python@2" => [:build, :optional]
+  depends_on "minimal-python"
 
   def install
     args = %W[
@@ -27,9 +24,9 @@ class XcbProto < Formula
       --disable-silent-rules
     ]
 
+    system "./autogen.sh"
     system "./configure", *args
     system "make"
-    system "make", "check" if build.with? "test"
     system "make", "install"
   end
 end


### PR DESCRIPTION
These depencies are only needed for the tests, and make the dependency
tree too big (and create circular dependencies for tcl-tk and python).

Remove the test too, as we almost never run tests a build time.

