### PR TITLE
libxt: make check requires glib

### DIFF
--- a/Formula/libxt.rb
+++ b/Formula/libxt.rb
@@ -13,9 +13,8 @@ class Libxt < Formula
   option "without-test", "Skip compile-time tests"
   option "with-static", "Build static libraries (not recommended)"
   option "with-specs", "Build specifications"
-  option "with-glib", "Build with glib (for unit testing)"
 
-  depends_on "glib" => [:build, :optional]
+  depends_on "glib" => :build if build.with "test"
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/libice"
   depends_on "linuxbrew/xorg/libsm"


### PR DESCRIPTION
Fix the error:
```
error: glib.h: No such file or directory compilation terminated.
```

See https://github.com/Linuxbrew/homebrew-xorg/issues/460

This PR may be squash merged without updating the bottle.