### PR TITLE
libxt: Make running tests optional

### DIFF
--- a/Formula/libxt.rb
+++ b/Formula/libxt.rb
@@ -10,7 +10,7 @@ class Libxt < Formula
     sha256 "7898201b493d05244375a0d092f3f642e4435ea7fd08ce95a1d8a5e288d83e44" => :x86_64_linux
   end
 
-  option "without-test", "Skip compile-time tests"
+  option "with-test", "Run compile-time tests"
   option "with-static", "Build static libraries (not recommended)"
   option "with-specs", "Build specifications"
 


### PR DESCRIPTION
This simplifies the dependency tree: it removes glib, meson, ninja
and Python.

