### PR TITLE
TravisCI: keep zlib1g-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ before_install:
       x11proto-input-dev
       x11proto-kb-dev
       x11proto-xext-dev
+  - sudo rm -rf /usr/local/clang-5.0.0
   - git config --global user.name "Travis CI"
   - git config --global user.email "travis-ci@linuxbrew.sh"
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ before_install:
       x11proto-input-dev
       x11proto-kb-dev
       x11proto-xext-dev
-      zlib1g-dev
   - git config --global user.name "Travis CI"
   - git config --global user.email "travis-ci@linuxbrew.sh"
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"


### PR DESCRIPTION
Running `brew style linuxbrew/xorg` initiates installation of `nokogiri`, which requires `zlib`:

https://travis-ci.org/Linuxbrew/homebrew-xorg/builds/550468121#L1466

> current directory:
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/nokogiri-1.10.3/ext/nokogiri
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/bin/ruby
-r ./siteconf20190625-11981-1betp30.rb extconf.rb
checking if the C compiler accepts ... yes
Building nokogiri using packaged libraries.
Using mini_portile version 2.4.0
checking for gzdopen() in -lz... no
zlib is missing; necessary for building libxml2