### PR TITLE
xcb-util-keysyms add lost build dependency binutils.

### DIFF
--- a/Formula/xcb-util-keysyms.rb
+++ b/Formula/xcb-util-keysyms.rb
@@ -8,6 +8,7 @@ class XcbUtilKeysyms < Formula
   option "with-static", "Build static libraries (not recommended)"
   option "with-docs", "Regenerate documentation (requires doxygen)"
 
+  depends_on "binutils" => :build
   depends_on "doxygen" => :build if build.with? "docs"
   depends_on "linuxbrew/xorg/util-macros" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

