### PR TITLE
mesa: strip binaries; move to python 3.8

### DIFF
--- a/Formula/glu.rb
+++ b/Formula/glu.rb
@@ -3,11 +3,11 @@ class Glu < Formula
   homepage "https://cgit.freedesktop.org/mesa/glu"
   url "ftp://ftp.freedesktop.org/pub/mesa/glu/glu-9.0.1.tar.xz"
   sha256 "fb5a4c2dd6ba6d1c21ab7c05129b0769544e1d68e1e3b0ffecb18e73c93055bc"
+  revision 1
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
-    sha256 "4224f8bb39d9ee78f1959fae152bab7f1dba6b8bbe666bf9a423e88c143aacaa" => :x86_64_linux
   end
 
   depends_on "libtool" => :build

--- a/Formula/xdriinfo.rb
+++ b/Formula/xdriinfo.rb
@@ -5,10 +5,11 @@ class Xdriinfo < Formula
   url "https://www.x.org/pub/individual/app/xdriinfo-1.0.6.tar.bz2"
   mirror "https://ftp.x.org/pub/individual/app/xdriinfo-1.0.6.tar.bz2"
   sha256 "d9ccd2c3e87899417acc9ea1f3e319a4198112babe1dc711273584f607449d51"
+  revision 1
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
-    sha256 "680bea023686a32b12077bc0c18b64875364bdbe08ee11c63b529fcf8a3b4a22" => :x86_64_linux
   end
 
   # tag "linuxbrew"


### PR DESCRIPTION
The size of mesa after installation is around 2.6 Gb,
after striping less than 300M.

# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?

