### PR TITLE
workflows: setup CI for bottle publishing

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -1,0 +1,134 @@
+name: Publish and commit bottles
+
+on: repository_dispatch
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    env:
+      HOMEBREW_DEVELOPER: 1
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - name: Set up git information
+        uses: actions/github-script@0.9.0
+        id: env
+        with:
+          script: |
+            const user = await github.users.getByUsername({
+              username: context.actor
+            })
+            const email = (user.data.email || user.data.id + "+" + user.data.login + "@users.noreply.github.com")
+            const name = (user.data.name || user.data.login)
+            console.log("Dispatched by " + name + " <" + email + ">")
+            core.setOutput("name", name)
+            core.setOutput("email", email)
+      - name: Post comment once started
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+          script: |
+            const run_id = process.env.GITHUB_RUN_ID
+            const actor = context.actor
+            const pr = context.payload.client_payload.pull_request
+            console.log("run_id=" + run_id)
+            console.log("actor=" + actor)
+            console.log("pr=" + pr)
+
+            const repository = context.repo.owner + '/' + context.repo.repo
+            const url = 'https://github.com/' + repository + '/actions/runs/' + run_id
+
+            let comment = ''
+            if (actor == 'BrewTestBot') {
+                comment += ':robot: A scheduled task'
+            } else {
+                comment += ':shipit: @' + actor
+            }
+            comment += ' has [triggered a merge](' + url + ').'
+
+            github.issues.createComment({
+              ...context.repo,
+              issue_number: pr,
+              body: comment
+            })
+      - name: Update Homebrew
+        run: |
+          brew update-reset $(brew --repository)
+      - name: Checkout tap
+        uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          fetch-depth: 0
+      - name: Setup tap
+        run: |
+          rm -rf $(brew --repository ${{github.repository}})
+          ln -s $GITHUB_WORKSPACE $(brew --repository ${{github.repository}})
+      - name: Setup git
+        run: |
+          git config --global user.name "${{steps.env.outputs.name}}"
+          git config --global user.email "${{steps.env.outputs.email}}"
+      - name: Pull bottles
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          HOMEBREW_BINTRAY_USER: ${{secrets.BINTRAY_USER}}
+          HOMEBREW_BINTRAY_KEY: ${{secrets.BINTRAY_KEY}}
+        run: |
+          brew pr-pull --verbose ${{github.event.client_payload.pull_request}}
+      - name: Push commits
+        run: |
+          for try in $(seq 20); do
+            git fetch
+            git rebase origin/master
+            if git push; then
+              exit 0
+            else
+              max=$(( $try + 10 ))
+              sleep $(shuf -i 3-$max -n 1)
+            fi
+          done
+          exit 1
+      - name: Post comment on failure
+        if: ${{!success()}}
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const run_id = process.env.GITHUB_RUN_ID
+            const actor = context.actor
+            const pr = context.payload.client_payload.pull_request
+            const repository = context.repo.owner + '/' + context.repo.repo
+            const url = 'https://github.com/' + repository + '/actions/runs/' + run_id
+
+            console.log("run_id=" + run_id)
+            console.log("actor=" + actor)
+            console.log("pr=" + pr)
+
+            let comment = ':warning: '
+            if (actor != 'BrewTestBot') {
+                comment += '@' + actor
+            }
+            let status = '${{job.status}}'.toLowerCase()
+            comment += ' bottle publish [' + status + '](' + url + ').'
+
+            github.issues.createComment({
+              ...context.repo,
+              issue_number: pr,
+              body: comment
+            })
+
+            const reviews = await github.pulls.listReviews({
+              ...context.repo,
+              pull_number: pr
+            })
+
+            for (const review of reviews.data) {
+              if (review.state != "APPROVED")
+                continue
+
+              github.pulls.dismissReview({
+                ...context.repo,
+                pull_number: pr,
+                review_id: review.id,
+                message: "bottle publish failed"
+              });
+            }

--- a/.github/workflows/test_pull_requests.yml
+++ b/.github/workflows/test_pull_requests.yml
@@ -1,96 +1,80 @@
-name: CI for PRs
+name: GitHub Actions CI
 
-on:
-  pull_request:
-    paths:
-      - 'Formula/*.rb'
-      - 'Patches/*'
-      - '.github/workflows/*.yml'
+on: pull_request
 
 jobs:
-  audit:
-    name: Audit
+  tap_syntax:
     runs-on: ubuntu-latest
-    container:
-      image: homebrew/brew
-      env:
-        HOMEBREW_NO_ANALYTICS: 1
-        HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - uses: actions/checkout@master
-      - run: brew audit Formula/*.rb
+      - name: Check out tap
+        uses: actions/checkout@v2
 
-  build-bottles:
-    name: Build bottles
-    needs: audit
+      - name: Set up tap
+        run: |
+          mkdir -p $(dirname $(brew --repository ${{github.repository}}))
+          ln -s $GITHUB_WORKSPACE $(brew --repository ${{github.repository}})
+
+      - name: Install taps
+        run: |
+          # Install taps needed for 'brew tests' and 'brew man'
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          cd "$(brew --repo)"
+          brew tap homebrew/test-bot
+
+      - name: Run brew test-bot --only-tap-syntax
+        run: brew test-bot --only-tap-syntax
+
+  tests:
+    needs: tap_syntax
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     container:
       image: homebrew/brew
-      env:
-        HOMEBREW_NO_ANALYTICS: 1
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_TEMP: /tmp
-        HOMEBREW_VERBOSE: 1
     steps:
-      - uses: actions/checkout@master
-      - name: Build bottles
+      - name: Check out tap
+        uses: actions/checkout@v2
+
+      - name: Set up tap
         run: |
-          mkdir -p $(dirname $(brew --repo ${{github.repository}}))
-          cp -a "$GITHUB_WORKSPACE" "$(brew --repo ${{github.repository}})"
+          mkdir -p $(dirname $(brew --repository ${{github.repository}}))
+          ln -s $GITHUB_WORKSPACE $(brew --repository ${{github.repository}})
+
+      - name: Run brew test-bot --only-setup
+        run: brew test-bot --only-setup
+
+      - name: Run brew test-bot --only-formulae
+        run: |
           mkdir ~/bottles
           cd ~/bottles
           brew test-bot \
-              --tap=linuxbrew/xorg \
-              --bintray-org=linuxbrew \
-              --skip-recursive-dependents
-          cp -a ~/bottles $RUNNER_TEMP/
-      - name: Store artifacts
+            --tap=linuxbrew/xorg \
+            --only-formulae \
+            --keep-old \
+            --bintray-org=linuxbrew \
+            --skip-recursive-dependents
+
+      - name: Output brew test-bot --only-formulae failures
+        if: always()
+        run: |
+          cat ~/bottles/steps_output.txt
+          rm ~/bottles/steps_output.txt
+
+      - name: Count bottles
+        id: bottles
+        if: always()
+        run: |
+          cd ~/bottles
+          count=$(ls *.json | wc -l | xargs echo -n)
+          echo "$count bottles"
+          echo "::set-output name=count::$count"
+
+      - name: Move bottles
+        if: always() && steps.bottles.outputs.count > 0
+        run: mv ~/bottles $GITHUB_WORKSPACE
+
+      - name: Upload bottles
+        if: always() && steps.bottles.outputs.count > 0
         uses: actions/upload-artifact@v1
         with:
           name: bottles
-          path: ${{runner.temp}}/bottles
-
-  upload-bottles:
-    name: Upload bottles to Bintray
-    needs: build-bottles
-    runs-on: ubuntu-latest
-    container: 
-      image: homebrew/brew
-      env:
-        HOMEBREW_NO_ANALYTICS: 1
-        HOMEBREW_NO_AUTO_UPDATE: 1
-    steps:
-      - name: Retrieve artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: bottles
-      - name: Set up SSH keys and basic Git information
-        uses: Homebrew/actions/git-ssh@master
-        with:
-          git_user: LinuxbrewTestBot
-          git_email: testbot@linuxbrew.sh
-          key: ${{secrets.SSH_KEY}}
-      - name: Upload bottles
-        env:
-          HOMEBREW_BINTRAY_USER: ${{secrets.BINTRAY_USER}}
-          HOMEBREW_BINTRAY_KEY: ${{secrets.BINTRAY_KEY}}
-          UPSTREAM_PULL_REQUEST: ${{github.event.pull_request.number}}
-        run: |
-          cd bottles
-          brew update-reset
-          brew test-bot \
-              --bintray-org=linuxbrew \
-              --git-name=LinuxbrewTestBot \
-              --git-email=testbot@linuxbrew.sh \
-              --ci-upload
-
-  check-tag:
-    name: Check tag in LinuxbrewTestBot
-    needs: upload-bottles
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          curl --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-               --get --fail \
-               https://api.github.com/repos/LinuxbrewTestBot/homebrew-xorg/git/ref/tags/pr-${{github.event.pull_request.number}} \
-               &>/dev/null
+          path: bottles


### PR DESCRIPTION
This is basically:
- The same test_pull_requests.yml file as the test.yml file in linuxbrew-core
- publish-commit-bottles.yml from homebrew-core, with some small simplification as it runs only on Linux.

@dawidd6 I need your sharp eyes on this, I hope I got the logic right.

We need to change `brew pr-publish` to support taps I guess?