### PR TITLE
xrdb: Fix cpp usage

### DIFF
--- a/Formula/xrdb.rb
+++ b/Formula/xrdb.rb
@@ -37,6 +37,6 @@ class Xrdb < Formula
       Version: VERSION
     EOF
     cmd = "xrdb -global -n xversion"
-    assert_match "Version:\t12", shell_output(cmd).chomp
+    assert_match "Version:\t11", shell_output(cmd).chomp
   end
 end

--- a/Formula/xrdb.rb
+++ b/Formula/xrdb.rb
@@ -14,6 +14,7 @@ class Xrdb < Formula
 
   depends_on "linuxbrew/xorg/util-macros" => :build
   depends_on "pkg-config" => :build
+  depends_on "gcc"
   depends_on "linuxbrew/xorg/libxmu"
 
   def install
@@ -23,11 +24,19 @@ class Xrdb < Formula
       --localstatedir=#{var}
       --disable-dependency-tracking
       --disable-silent-rules
+      --with-cpp=#{Formula["gcc"].opt_bin}/cpp
     ]
-    # --with-cpp=path  # comma-separated list of paths to cpp command for xrdb to use at runtime
 
     system "./configure", *args
     system "make"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"xversion").write <<~EOF
+      Version: VERSION
+    EOF
+    cmd = "xrdb -global -n xversion"
+    assert_match "Version:\t12", shell_output(cmd).chomp
   end
 end


### PR DESCRIPTION
Currently, xrdb has a reference to Homebrew's cpp shim,
which fails at runtime with:

cpp: The build tool has reset ENV; --env=std required.

Also add a test.

# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?