### PR TITLE
Update Xorg to current LivecheckStrategy format

### DIFF
--- a/livecheck_strategy/xorg.rb
+++ b/livecheck_strategy/xorg.rb
@@ -2,8 +2,7 @@
 
 module LivecheckStrategy
   class Xorg
-    NICE_NAME = "Xorg"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     def self.match?(url)
       /(...\.x\.org|freedesktop\.org)/.match?(url)


### PR DESCRIPTION
# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

---

Homebrew/homebrew-livecheck#1025 is now merged, so I'm updating the `Xorg` strategy here to the reflect the current `LivecheckStrategy` format.

Namely, there were some changes around `NAME` and `NICE_NAME` between the time this `Xorg` strategy was created and the aforementioned PR was merged:

* `NAME` should now always be `NAME = name.demodulize` (like the built-in strategies)
* `NICE_NAME` should only be provided when it differs from the class name. Using `Sourceforge` as an example, the class name has to be `Sourceforge` (so the strategy symbol is `:sourceforge`) and we set `NICE_NAME = "SourceForge"` to make the nicer name available. We currently don't use `NICE_NAME` anywhere inside livecheck, so it may be removed in the future but I'm making it available for now.