### PR TITLE
Integrate livecheckables into formulae

### DIFF
--- a/Formula/intel-media-driver.rb
+++ b/Formula/intel-media-driver.rb
@@ -4,6 +4,11 @@ class IntelMediaDriver < Formula
   url "https://github.com/intel/media-driver/archive/intel-media-19.4.0r.tar.gz"
   sha256 "a03bd75eefe9cb0245e3aab2723b3fef555d9f180a180b2c29d7b12d483d9ec2"
 
+  livecheck do
+    url "https://github.com/intel/media-driver/releases"
+    regex(%r{Latest.*?href="/intel/media-driver/archive/intel-media-?([a-z0-9.]+).tar.gz}m)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "27e721bb9b49179017e50998da0847a72658452870964963aab109e2c58fd2d7" => :x86_64_linux

--- a/Formula/libdmx.rb
+++ b/Formula/libdmx.rb
@@ -5,6 +5,11 @@ class Libdmx < Formula
   sha256 "253f90005d134fa7a209fbcbc5a3024335367c930adf0f3203e754cf32747243"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libdmx-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libfontenc.rb
+++ b/Formula/libfontenc.rb
@@ -5,6 +5,11 @@ class Libfontenc < Formula
   sha256 "2cfcce810ddd48f2e5dc658d28c1808e86dcf303eaff16728b9aa3dbc0092079"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libfontenc-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libfs.rb
+++ b/Formula/libfs.rb
@@ -5,6 +5,11 @@ class Libfs < Formula
   sha256 "c8e13727149b2ddfe40912027459b2522042e3844c5cd228c3300fe5eef6bd0f"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libFS-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "c34c9e927c96b690e558126c1df486650c8154984f5ad5582e8f2a6c0cfb17ec" => :x86_64_linux

--- a/Formula/libice.rb
+++ b/Formula/libice.rb
@@ -5,6 +5,11 @@ class Libice < Formula
   sha256 "6f86dce12cf4bcaf5c37dddd8b1b64ed2ddf1ef7b218f22b9942595fb747c348"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libICE-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "23a15495adac70a5fb0fbdcbf2edf956ef4178d1859d5d78ec83cdeaf9ac3669" => :x86_64_linux

--- a/Formula/libpciaccess.rb
+++ b/Formula/libpciaccess.rb
@@ -5,6 +5,11 @@ class Libpciaccess < Formula
   sha256 "214c9d0d884fdd7375ec8da8dcb91a8d3169f263294c9a90c575bf1938b9f489"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libpciaccess-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "5c6a257b582d4556203bc73fa9bdc525194896459ed88a8b07af0d83154ab656" => :x86_64_linux

--- a/Formula/libpthread-stubs.rb
+++ b/Formula/libpthread-stubs.rb
@@ -5,6 +5,11 @@ class LibpthreadStubs < Formula
   sha256 "e4d05911a3165d3b18321cc067fdd2f023f06436e391c6a28dff618a78d2e733"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://xcb.freedesktop.org/dist"
+    regex(/libpthread-stubs-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libsm.rb
+++ b/Formula/libsm.rb
@@ -5,6 +5,11 @@ class Libsm < Formula
   sha256 "2d264499dcb05f56438dee12a1b4b71d76736ce7ba7aa6efbf15ebb113769cbb"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libSM-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libva-intel-driver.rb
+++ b/Formula/libva-intel-driver.rb
@@ -4,6 +4,11 @@ class LibvaIntelDriver < Formula
   url "https://github.com/intel/intel-vaapi-driver/releases/download/2.4.0/intel-vaapi-driver-2.4.0.tar.bz2"
   sha256 "71e2ddd985af6b221389db1018c4e8ca27a7f939fb51dcdf49d0efcb5ff3d089"
 
+  livecheck do
+    url "https://github.com/intel/intel-vaapi-driver/releases"
+    regex(%r{Latest.*?href="/intel/intel-vaapi-driver/tree/v?([a-z0-9.]+)}m)
+  end
+
   bottle do
     sha256 "5d6cb7e16619d29f46d47d218304b8104f10c01b139470e298d98d6cc46faec5" => :x86_64_linux
   end

--- a/Formula/libva-internal.rb
+++ b/Formula/libva-internal.rb
@@ -4,6 +4,11 @@ class LibvaInternal < Formula
   url "https://github.com/intel/libva/releases/download/2.6.1/libva-2.6.1.tar.bz2"
   sha256 "6c57eb642d828af2411aa38f55dc10111e8c98976dbab8fd62e48629401eaea5"
 
+  livecheck do
+    url "https://github.com/intel/libva/releases"
+    regex(%r{Latest.*?href="/intel/libva/tree/v?([a-z0-9.]+)}m)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libva.rb
+++ b/Formula/libva.rb
@@ -4,6 +4,11 @@ class Libva < Formula
   url "https://github.com/intel/libva/releases/download/2.6.1/libva-2.6.1.tar.bz2"
   sha256 "6c57eb642d828af2411aa38f55dc10111e8c98976dbab8fd62e48629401eaea5"
 
+  livecheck do
+    url "https://github.com/intel/libva/releases"
+    regex(%r{Latest.*?href="/intel/libva/tree/v?([a-z0-9.]+)}m)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libvdpau-va-gl.rb
+++ b/Formula/libvdpau-va-gl.rb
@@ -4,6 +4,11 @@ class LibvdpauVaGl < Formula
   url "https://github.com/i-rinat/libvdpau-va-gl/releases/download/v0.4.2/libvdpau-va-gl-0.4.2.tar.gz"
   sha256 "7d9121540658eb0244859e63da171ca3869e784afbeaf202f44471275c784af4"
 
+  livecheck do
+    url "https://github.com/i-rinat/libvdpau-va-gl/releases"
+    regex(%r{Latest.*?href="/i-rinat/libvdpau-va-gl/tree/v?([a-z0-9.]+)}m)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "f9dd19e3c9891c6bf27f5a742f717d985e4aafdbcadf9b40d49f70d3a4038c7e" => :x86_64_linux

--- a/Formula/libwacom.rb
+++ b/Formula/libwacom.rb
@@ -4,6 +4,11 @@ class Libwacom < Formula
   url "https://github.com/linuxwacom/libwacom/releases/download/libwacom-1.2/libwacom-1.2.tar.bz2"
   sha256 "c204cfdee2159d124a4f5ecc8970bbd72f9adf5ad7fd94b66798f93db1f863c3"
 
+  livecheck do
+    url "https://github.com/linuxwacom/libwacom/releases"
+    regex(/libwacom-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     sha256 "3327d3c856f9df270c886a98f1af90b1ead38659f9ca39d91fa84336c1441954" => :x86_64_linux
   end

--- a/Formula/libx11.rb
+++ b/Formula/libx11.rb
@@ -5,6 +5,11 @@ class Libx11 < Formula
   sha256 "9cc7e8d000d6193fa5af580d50d689380b8287052270f5bb26a5fb6b58b2bed1"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libX11-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     sha256 "761a6d9d3974cab7b5aedeaec8bc4c037318f6eed8aee00bcb8e01dde15d9a59" => :x86_64_linux
   end

--- a/Formula/libxau.rb
+++ b/Formula/libxau.rb
@@ -5,6 +5,11 @@ class Libxau < Formula
   sha256 "ccf8cbf0dbf676faa2ea0a6d64bcc3b6746064722b606c8c52917ed00dcb73ec"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXau-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libxaw.rb
+++ b/Formula/libxaw.rb
@@ -5,6 +5,11 @@ class Libxaw < Formula
   sha256 "8ef8067312571292ccc2bbe94c41109dcf022ea5a4ec71656a83d8cce9edb0cd"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXaw-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     sha256 "427db63fe8e595a92a5a2de288137a57d7eff69aeb2764f41b758aab2f6bb305" => :x86_64_linux
   end

--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -5,6 +5,11 @@ class Libxcb < Formula
   sha256 "a89fb7af7a11f43d2ce84a844a4b38df688c092bf4b67683aef179cdf2a647c4"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libxcb-([0-9.]+)\.tar.gz/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libxcomposite.rb
+++ b/Formula/libxcomposite.rb
@@ -5,6 +5,11 @@ class Libxcomposite < Formula
   sha256 "b3218a2c15bab8035d16810df5b8251ffc7132ff3aa70651a1fba0bfe9634e8f"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXcomposite-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "5cf6cc0b18a15c3fdb80b0010a474d932ef8e4f25d537ce3f2cada9939a0f385" => :x86_64_linux

--- a/Formula/libxcursor.rb
+++ b/Formula/libxcursor.rb
@@ -5,6 +5,11 @@ class Libxcursor < Formula
   sha256 "3ad3e9f8251094af6fe8cb4afcf63e28df504d46bfa5a5529db74a505d628782"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXcursor-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "2a49eacd71d2b4032ecc40ddb6d2f8f4ce8d1e4af7ba12fe7d64543e4997f2b4" => :x86_64_linux

--- a/Formula/libxdamage.rb
+++ b/Formula/libxdamage.rb
@@ -5,6 +5,11 @@ class Libxdamage < Formula
   sha256 "b734068643cac3b5f3d2c8279dd366b5bf28c7219d9e9d8717e1383995e0ea45"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXdamage-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "d9c30c357ddba1b40626b060e1687f647c33bd2ea3add5a64d5fb22157553324" => :x86_64_linux

--- a/Formula/libxdmcp.rb
+++ b/Formula/libxdmcp.rb
@@ -5,6 +5,11 @@ class Libxdmcp < Formula
   sha256 "20523b44aaa513e17c009e873ad7bbc301507a3224c232610ce2e099011c6529"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXdmcp-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "f8d257f11b6b31026b006a1a5fcc577a9fe0def4e73e9657d377a4e431ee6706" => :x86_64_linux

--- a/Formula/libxext.rb
+++ b/Formula/libxext.rb
@@ -5,6 +5,11 @@ class Libxext < Formula
   sha256 "59ad6fcce98deaecc14d39a672cf218ca37aba617c9a0f691cac3bcd28edf82b"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXext-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "e3af172c81646ce9bc6b40c5d28a294d5493286ff80fdddbf53a07a0f43642f2" => :x86_64_linux

--- a/Formula/libxfixes.rb
+++ b/Formula/libxfixes.rb
@@ -5,6 +5,11 @@ class Libxfixes < Formula
   sha256 "de1cd33aff226e08cefd0e6759341c2c8e8c9faf8ce9ac6ec38d43e287b22ad6"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXfixes-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "de00528cfeec544e7e0a6dea7be947dc098440268002f68f215587a10e692ce9" => :x86_64_linux

--- a/Formula/libxfont.rb
+++ b/Formula/libxfont.rb
@@ -5,6 +5,11 @@ class Libxfont < Formula
   sha256 "1a7f7490774c87f2052d146d1e0e64518d32e6848184a18654e8d0bb57883242"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXfont-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libxfont2.rb
+++ b/Formula/libxfont2.rb
@@ -5,6 +5,11 @@ class Libxfont2 < Formula
   sha256 "6d151b3368e5035efede4b6264c0fdc6662c1c99dbc2de425e3480cababc69e6"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXfont2-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "a97247cb6e4d50a2e74cbaf071fb7b4dfc09271380089bc7887d4720645a4d39" => :x86_64_linux

--- a/Formula/libxfontcache.rb
+++ b/Formula/libxfontcache.rb
@@ -5,6 +5,11 @@ class Libxfontcache < Formula
   url "https://www.x.org/archive/individual/lib/libXfontcache-1.0.5.tar.gz"
   sha256 "fdba75307a0983d2566554e0e9effa7079551f1b7b46e8de642d067998619659"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXfontcache-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libxft.rb
+++ b/Formula/libxft.rb
@@ -5,6 +5,11 @@ class Libxft < Formula
   sha256 "225c68e616dd29dbb27809e45e9eadf18e4d74c50be43020ef20015274529216"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXft-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "5d6f440da2a9fc76383bdf7c8157ae6d253fca26773abc5bf341eb30ab3aa3ac" => :x86_64_linux

--- a/Formula/libxi.rb
+++ b/Formula/libxi.rb
@@ -5,6 +5,11 @@ class Libxi < Formula
   sha256 "36a30d8f6383a72e7ce060298b4b181fd298bc3a135c8e201b7ca847f5f81061"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXi-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "945af08c6e1d961e3f06fe14d735208ed2979a84bc62315b057bfeb61bff8bae" => :x86_64_linux

--- a/Formula/libxinerama.rb
+++ b/Formula/libxinerama.rb
@@ -5,6 +5,11 @@ class Libxinerama < Formula
   sha256 "0008dbd7ecf717e1e507eed1856ab0d9cf946d03201b85d5dcf61489bb02d720"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXinerama-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libxkbfile.rb
+++ b/Formula/libxkbfile.rb
@@ -5,6 +5,11 @@ class Libxkbfile < Formula
   sha256 "758dbdaa20add2db4902df0b1b7c936564b7376c02a0acd1f2a331bd334b38c7"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libxkbfile-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any
     sha256 "1e943ae60d762337e4b9f2b989e58bed91856640f5b2facbb31b5e9560f59b1d" => :x86_64_linux

--- a/Formula/libxmu.rb
+++ b/Formula/libxmu.rb
@@ -5,6 +5,11 @@ class Libxmu < Formula
   sha256 "9c343225e7c3dc0904f2122b562278da5fed639b1b5e880d25111561bac5b731"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXmu-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "16e19650d21bde3a7e74ec780c36632337fd931e1c9bbd01f40506508bf0de31" => :x86_64_linux

--- a/Formula/libxpm.rb
+++ b/Formula/libxpm.rb
@@ -5,6 +5,11 @@ class Libxpm < Formula
   sha256 "fd6a6de3da48de8d1bb738ab6be4ad67f7cb0986c39bd3f7d51dd24f7854bdec"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXpm-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     sha256 "8c41260ec185a5a4ae26c6e3b173f7fcdd46d26b1807f2b749595eac1c344d9e" => :x86_64_linux
   end

--- a/Formula/libxrandr.rb
+++ b/Formula/libxrandr.rb
@@ -5,6 +5,11 @@ class Libxrandr < Formula
   sha256 "8aea0ebe403d62330bb741ed595b53741acf45033d3bda1792f1d4cc3daee023"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXrandr-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "3ee2eb9da710235f373e0f88ed3880570121a380ce4dbd09a921f2061c9fa18f" => :x86_64_linux

--- a/Formula/libxrender.rb
+++ b/Formula/libxrender.rb
@@ -5,6 +5,11 @@ class Libxrender < Formula
   sha256 "c06d5979f86e64cabbde57c223938db0b939dff49fdb5a793a1d3d0396650949"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXrender-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "f97a8833f5bcaabd12e10bac82a644e18f8c39dc4b637b2afaf4227122ce907c" => :x86_64_linux

--- a/Formula/libxres.rb
+++ b/Formula/libxres.rb
@@ -5,6 +5,11 @@ class Libxres < Formula
   sha256 "ff75c1643488e64a7cfbced27486f0f944801319c84c18d3bd3da6bf28c812d4"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXres-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libxscrnsaver.rb
+++ b/Formula/libxscrnsaver.rb
@@ -5,6 +5,11 @@ class Libxscrnsaver < Formula
   sha256 "f917075a1b7b5a38d67a8b0238eaab14acd2557679835b154cf2bca576e89bf8"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXScrnSaver-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libxshmfence.rb
+++ b/Formula/libxshmfence.rb
@@ -5,6 +5,11 @@ class Libxshmfence < Formula
   sha256 "b884300d26a14961a076fbebc762a39831cb75f92bed5ccf9836345b459220c7"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libxshmfence-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libxt.rb
+++ b/Formula/libxt.rb
@@ -5,6 +5,11 @@ class Libxt < Formula
   sha256 "b31df531dabed9f4611fc8980bc51d7782967e2aff44c4105251a1acb5a77831"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXt-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "ca44976ced1812ee671599b1476f2579bd55790a771b66ef6a2c1ef3fe07c3b8" => :x86_64_linux

--- a/Formula/libxtst.rb
+++ b/Formula/libxtst.rb
@@ -6,6 +6,11 @@ class Libxtst < Formula
   sha256 "4655498a1b8e844e3d6f21f3b2c4e2b571effb5fd83199d428a6ba7ea4bf5204"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXtst-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "883e02960643d1b58e7a2cd860f7c2d4bc3e77c38ca5b2216a24a4593a93852b" => :x86_64_linux

--- a/Formula/libxv.rb
+++ b/Formula/libxv.rb
@@ -5,6 +5,11 @@ class Libxv < Formula
   sha256 "d26c13eac99ac4504c532e8e76a1c8e4bd526471eb8a0a4ff2a88db60cb0b088"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXv-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "ae94f4a82954b7d96b43b21a302c78411da9e5fc9074b35976a53c24fcd02c71" => :x86_64_linux

--- a/Formula/libxvmc.rb
+++ b/Formula/libxvmc.rb
@@ -5,6 +5,11 @@ class Libxvmc < Formula
   sha256 "6b3da7977b3f7eaf4f0ac6470ab1e562298d82c4e79077765787963ab7966dcd"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/libXvMC-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "923a37dabf7caa36ec003d5679669eb5ed89e64312411005dfe2e6c38652f4fe" => :x86_64_linux

--- a/Formula/xtrans.rb
+++ b/Formula/xtrans.rb
@@ -5,6 +5,11 @@ class Xtrans < Formula
   sha256 "377c4491593c417946efcd2c7600d1e62639f7a8bbca391887e2c4679807d773"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://ftp.x.org/archive/individual/lib/"
+    regex(/xtrans-([0-9.]+)\.tar.bz2/)
+  end
+
   bottle do
     cellar :any_skip_relocation
     sha256 "71a00abeb9be73954af2152826a58370a9aada5a4eb02f3db480c0df5153cdb7" => :x86_64_linux

--- a/Livecheckables/intel-media-driver.rb
+++ b/Livecheckables/intel-media-driver.rb
@@ -1,6 +1,0 @@
-class IntelMediaDriver
-  livecheck do
-    url "https://github.com/intel/media-driver/releases"
-    regex(%r{Latest.*?href="/intel/media-driver/archive/intel-media-?([a-z0-9.]+).tar.gz}m)
-  end
-end

--- a/Livecheckables/libdmx.rb
+++ b/Livecheckables/libdmx.rb
@@ -1,6 +1,0 @@
-class Libdmx
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libdmx-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libfontenc.rb
+++ b/Livecheckables/libfontenc.rb
@@ -1,6 +1,0 @@
-class Libfontenc
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libfontenc-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libfs.rb
+++ b/Livecheckables/libfs.rb
@@ -1,6 +1,0 @@
-class Libfs
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libFS-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libice.rb
+++ b/Livecheckables/libice.rb
@@ -1,6 +1,0 @@
-class Libice
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libICE-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libpciaccess.rb
+++ b/Livecheckables/libpciaccess.rb
@@ -1,6 +1,0 @@
-class Libpciaccess
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libpciaccess-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libpthread-stubs.rb
+++ b/Livecheckables/libpthread-stubs.rb
@@ -1,6 +1,0 @@
-class LibpthreadStubs
-  livecheck do
-    url "https://xcb.freedesktop.org/dist"
-    regex /libpthread-stubs-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libsm.rb
+++ b/Livecheckables/libsm.rb
@@ -1,6 +1,0 @@
-class Libsm
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libSM-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libva-intel-driver.rb
+++ b/Livecheckables/libva-intel-driver.rb
@@ -1,6 +1,0 @@
-class LibvaIntelDriver
-  livecheck do
-    url "https://github.com/intel/intel-vaapi-driver/releases"
-    regex %r{Latest.*?href="/intel/intel-vaapi-driver/tree/v?([a-z0-9.]+)}m
-  end
-end

--- a/Livecheckables/libva-internal.rb
+++ b/Livecheckables/libva-internal.rb
@@ -1,6 +1,0 @@
-class LibvaInternal
-  livecheck do
-    url "https://github.com/intel/libva/releases"
-    regex %r{Latest.*?href="/intel/libva/tree/v?([a-z0-9.]+)}m
-  end
-end

--- a/Livecheckables/libva.rb
+++ b/Livecheckables/libva.rb
@@ -1,6 +1,0 @@
-class Libva
-  livecheck do
-    url "https://github.com/intel/libva/releases"
-    regex %r{Latest.*?href="/intel/libva/tree/v?([a-z0-9.]+)}m
-  end
-end

--- a/Livecheckables/libvdpau-va-gl.rb
+++ b/Livecheckables/libvdpau-va-gl.rb
@@ -1,6 +1,0 @@
-class LibvdpauVaGl
-  livecheck do
-    url "https://github.com/i-rinat/libvdpau-va-gl/releases"
-    regex %r{Latest.*?href="/i-rinat/libvdpau-va-gl/tree/v?([a-z0-9.]+)}m
-  end
-end

--- a/Livecheckables/libwacom.rb
+++ b/Livecheckables/libwacom.rb
@@ -1,6 +1,0 @@
-class Libwacom
-  livecheck do
-    url "https://github.com/linuxwacom/libwacom/releases"
-    regex /libwacom-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libx11.rb
+++ b/Livecheckables/libx11.rb
@@ -1,6 +1,0 @@
-class Libx11
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libX11-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxau.rb
+++ b/Livecheckables/libxau.rb
@@ -1,6 +1,0 @@
-class Libxau
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXau-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxaw.rb
+++ b/Livecheckables/libxaw.rb
@@ -1,6 +1,0 @@
-class Libxaw
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXaw-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxcb.rb
+++ b/Livecheckables/libxcb.rb
@@ -1,6 +1,0 @@
-class Libxcb
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libxcb-([0-9.]+)\.tar.gz/
-  end
-end

--- a/Livecheckables/libxcomposite.rb
+++ b/Livecheckables/libxcomposite.rb
@@ -1,6 +1,0 @@
-class Libxcomposite
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXcomposite-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxcursor.rb
+++ b/Livecheckables/libxcursor.rb
@@ -1,6 +1,0 @@
-class Libxcursor
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXcursor-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxdamage.rb
+++ b/Livecheckables/libxdamage.rb
@@ -1,6 +1,0 @@
-class Libxdamage
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXdamage-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxdmcp.rb
+++ b/Livecheckables/libxdmcp.rb
@@ -1,6 +1,0 @@
-class Libxdmcp
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXdmcp-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxext.rb
+++ b/Livecheckables/libxext.rb
@@ -1,6 +1,0 @@
-class Libxext
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXext-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxfixes.rb
+++ b/Livecheckables/libxfixes.rb
@@ -1,6 +1,0 @@
-class Libxfixes
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXfixes-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxfont.rb
+++ b/Livecheckables/libxfont.rb
@@ -1,6 +1,0 @@
-class Libxfont
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXfont-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxfont2.rb
+++ b/Livecheckables/libxfont2.rb
@@ -1,6 +1,0 @@
-class Libxfont2
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXfont2-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxfontcache.rb
+++ b/Livecheckables/libxfontcache.rb
@@ -1,6 +1,0 @@
-class Libxfontcache
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXfontcache-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxft.rb
+++ b/Livecheckables/libxft.rb
@@ -1,6 +1,0 @@
-class Libxft
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXft-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxi.rb
+++ b/Livecheckables/libxi.rb
@@ -1,6 +1,0 @@
-class Libxi
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXi-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxinerama.rb
+++ b/Livecheckables/libxinerama.rb
@@ -1,6 +1,0 @@
-class Libxinerama
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXinerama-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxkbfile.rb
+++ b/Livecheckables/libxkbfile.rb
@@ -1,6 +1,0 @@
-class Libxkbfile
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libxkbfile-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxmu.rb
+++ b/Livecheckables/libxmu.rb
@@ -1,6 +1,0 @@
-class Libxmu
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXmu-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxpm.rb
+++ b/Livecheckables/libxpm.rb
@@ -1,6 +1,0 @@
-class Libxpm
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXpm-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxrandr.rb
+++ b/Livecheckables/libxrandr.rb
@@ -1,6 +1,0 @@
-class Libxrandr
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXrandr-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxrender.rb
+++ b/Livecheckables/libxrender.rb
@@ -1,6 +1,0 @@
-class Libxrender
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXrender-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxres.rb
+++ b/Livecheckables/libxres.rb
@@ -1,6 +1,0 @@
-class Libxres
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXres-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxscrnsaver.rb
+++ b/Livecheckables/libxscrnsaver.rb
@@ -1,6 +1,0 @@
-class Libxscrnsaver
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXScrnSaver-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxshmfence.rb
+++ b/Livecheckables/libxshmfence.rb
@@ -1,6 +1,0 @@
-class Libxshmfence
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libxshmfence-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxt.rb
+++ b/Livecheckables/libxt.rb
@@ -1,6 +1,0 @@
-class Libxt
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXt-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxtst.rb
+++ b/Livecheckables/libxtst.rb
@@ -1,6 +1,0 @@
-class Libxtst
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXtst-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxv.rb
+++ b/Livecheckables/libxv.rb
@@ -1,6 +1,0 @@
-class Libxv
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXv-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/libxvmc.rb
+++ b/Livecheckables/libxvmc.rb
@@ -1,6 +1,0 @@
-class Libxvmc
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /libXvMC-([0-9.]+)\.tar.bz2/
-  end
-end

--- a/Livecheckables/xtrans.rb
+++ b/Livecheckables/xtrans.rb
@@ -1,6 +1,0 @@
-class Xtrans
-  livecheck do
-    url "https://ftp.x.org/archive/individual/lib/"
-    regex /xtrans-([0-9.]+)\.tar.bz2/
-  end
-end


### PR DESCRIPTION
# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

---

The `brew livecheck` command will be migrated from Homebrew/homebrew-livecheck into Homebrew/brew in the not-too-distant future and we will be removing the `Formulary` extension that enables the use of files in a `Livecheckables` folder in the process.

The reason for this is that livecheckables will be integrated into formulae as a `livecheck` block. The current `livecheck` block format in livecheckables is a half-step in between. Livecheck has supported `livecheck` blocks in formulae for some time (and favors it over a livecheckable file) but we haven't yet migrated livecheckables in homebrew-livecheck to homebrew-core formulae as we need to take care of some other things first. [We're currently bringing existing livecheckables (namely, the older ones) up to existing standards before the migration.]

With all this in mind, there's no reason not to integrate the livecheckables in this repository into their corresponding formulae. Doing this now will prevent them from breaking after the Homebrew/brew migration, so I thought I would take a moment to take care of this.

Besides that, I also modified the `regex` calls to always use parentheses, since that's what we've standardized on for technical reasons.

I've confirmed that all checks for this tap work exactly the same both before and after these changes. Anything that worked before continues to work and anything that was broken is still broken (in the same manner).