### PR TITLE
xcb-proto, libxcb, libevdev: depend on Python@3.8

### DIFF
--- a/Formula/libevdev.rb
+++ b/Formula/libevdev.rb
@@ -15,7 +15,7 @@ class Libevdev < Formula
 
   depends_on "check" => :build if build.with? "test"
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
+  depends_on "python@3.8" => :build
 
   def install
     args = %W[

--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -3,6 +3,7 @@ class Libxcb < Formula
   homepage "https://www.x.org/" ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
   url "https://xcb.freedesktop.org/dist/libxcb-1.13.1.tar.bz2"
   sha256 "a89fb7af7a11f43d2ce84a844a4b38df688c092bf4b67683aef179cdf2a647c4"
+  revision 1
   # tag "linuxbrew"
 
   livecheck do
@@ -21,7 +22,7 @@ class Libxcb < Formula
 
   depends_on "linuxbrew/xorg/xcb-proto" => :build
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
+  depends_on "python@3.8" => :build
   depends_on "linuxbrew/xorg/libpthread-stubs" # xcb.pc references pthread-stubs
   depends_on "linuxbrew/xorg/libxau"
   depends_on "linuxbrew/xorg/libxdmcp"

--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -3,7 +3,7 @@ class XcbProto < Formula
   homepage "https://www.x.org/"
   url "https://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.bz2"
   sha256 "7b98721e669be80284e9bbfeab02d2d0d54cd11172b72271e47a2fe875e2bde1"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
@@ -15,7 +15,7 @@ class XcbProto < Formula
 
   depends_on "libxml2" => :build if build.with? "test"
   depends_on "pkg-config" => :build
-  depends_on "python" => :build
+  depends_on "python@3.8" => :build
 
   def install
     args = %W[
@@ -23,6 +23,7 @@ class XcbProto < Formula
       --sysconfdir=#{etc}
       --localstatedir=#{var}
       --disable-silent-rules
+      PYTHON=python3
     ]
 
     system "./configure", *args

--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -14,7 +14,7 @@ class XcbProto < Formula
   option "without-test", "Skip compile-time tests"
 
   depends_on "libxml2" => :build if build.with? "test"
-  depends_on "pkg-config" => :build
+  depends_on "pkg-config" => [:build, :test]
   depends_on "python@3.8" => :build
 
   def install
@@ -30,5 +30,9 @@ class XcbProto < Formula
     system "make"
     system "make", "check" if build.with? "test"
     system "make", "install"
+  end
+
+  test do
+    assert_equal "#{share}/xcb", shell_output("pkg-config --variable=xcbincludedir xcb-proto").chomp
   end
 end


### PR DESCRIPTION
# Contributing to homebrew-xorg:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)? **No. I did add a test for `xcb-proto` but not for `libxcb`, which will still fail until it gets one.**
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Following up on the audit failure I found on #662 . A few things worth noting:

* I bumped the revision on `xcb-proto` because its existing bottle had a python3.7 path.
* I also used the `PYTHON` environment variable to enforce python choice, as on my machine the initial result on building from source was python2.7
* Since `xcb-proto` got a revision bump, I decided `libxcb` should get one too
* `libevdev` on the other hand didn't get a revision bump, as it doesn't depend on either of the other two and I didn't see any Python references in the resulting installed directory (other than a URL).
* I'm assuming that anything that depends on `libxcb` should be rebuilt automatically on upgrade if necessary. So I didn't bump the revisions of stuff like `xcb-util-renderutil`. (I'm admittedly a little fuzzy on whether those will need rebuilds eventually or not).

Feel free to overrule me on any of these decisions.