### PR TITLE
glu: add head and livecheck block

### DIFF
--- a/Formula/glu.rb
+++ b/Formula/glu.rb
@@ -5,10 +5,21 @@ class Glu < Formula
   sha256 "fb5a4c2dd6ba6d1c21ab7c05129b0769544e1d68e1e3b0ffecb18e73c93055bc"
   revision 1
 
+  livecheck do
+    url :head
+    regex(/^(?:glu[._-])?v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "41b97b80a25d2ccd426ffbde60021eee2743540ee532b10bb6d521af63ff7cb5" => :x86_64_linux
+  end
+
+  head do
+    url "https://gitlab.freedesktop.org/mesa/glu.git"
+
+    depends_on "automake" => :build
   end
 
   depends_on "libtool" => :build
@@ -22,6 +33,7 @@ class Glu < Formula
       --disable-silent-rules
     ]
 
+    system "./autogen.sh", *args if build.head?
     system "./configure", *args
     system "make"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

This adds a `head` repository, along with some additional changes to allow building from HEAD.

The primary intention here was to add a `livecheck` block, as this formula needs one to work properly.