### PR TITLE
libdrm: add livecheck block

### DIFF
--- a/Formula/libdrm.rb
+++ b/Formula/libdrm.rb
@@ -4,6 +4,11 @@ class Libdrm < Formula
   url "https://dri.freedesktop.org/libdrm/libdrm-2.4.100.tar.bz2"
   sha256 "c77cc828186c9ceec3e56ae202b43ee99eb932b4a87255038a80e8a1060d0a5d"
 
+  livecheck do
+    url "https://dri.freedesktop.org/libdrm/"
+    regex(/href=.*?libdrm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "3bdefcc3770ecdede8364dffb38a5d64f1f3dbb0c862d5a5ec08208b3609d8f6" => :x86_64_linux
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

This adds a `livecheck` block to `libdrm`, as it doesn't work properly without one.