### PR TITLE
libvdpau: add livecheck block

### DIFF
--- a/Formula/libvdpau.rb
+++ b/Formula/libvdpau.rb
@@ -4,6 +4,11 @@ class Libvdpau < Formula
   url "https://gitlab.freedesktop.org/vdpau/libvdpau/uploads/14b620084c027d546fa0b3f083b800c6/libvdpau-1.2.tar.bz2"
   sha256 "6a499b186f524e1c16b4f5b57a6a2de70dfceb25c4ee546515f26073cd33fa06"
 
+  livecheck do
+    url "https://gitlab.freedesktop.org/vdpau/libvdpau.git"
+    regex(/^(?:libvdpau[._-])?v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 "42119e870bf2f5c85b28fbfee63d42e62591b26c236088457ae16e60a320533c" => :x86_64_linux
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

This adds a `livecheck` block to `libvdpau `, as it doesn't work properly without one.

It's likely possible to add the Git repository as `head` but I didn't feel like fiddling with Meson to get the HEAD build working right now.