### PR TITLE
pciutils: add livecheck block

### DIFF
--- a/Formula/pciutils.rb
+++ b/Formula/pciutils.rb
@@ -5,6 +5,11 @@ class Pciutils < Formula
   sha256 "2bf3a4605a562fb6b8b7673bff85a474a5cf383ed7e4bd8886b4f0939013d42f"
   # tag "linuxbrew"
 
+  livecheck do
+    url "https://www.kernel.org/pub/software/utils/pciutils/"
+    regex(/href=.*?pciutils[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 "a824aca17f0b34dcc21ea46674213d0a71d213e2bb69e7314f8d8113468cb649" => :x86_64_linux
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

This adds a `livecheck` block to `pciutils`, as it doesn't work properly without one.