### PR TITLE
xorg, xorg-apps, xorg-fonts: add livecheck block

### DIFF
--- a/Formula/xorg-apps.rb
+++ b/Formula/xorg-apps.rb
@@ -7,6 +7,10 @@ class XorgApps < Formula
   sha256   "d6f8969d76bd3236c40e57fc3f498c43341f3f1e9ae01c4c2bca11876f07adc6"
   # tag "linuxbrew"
 
+  livecheck do
+    skip "Formula only installs other formulae"
+  end
+
   bottle :unneeded
 
   depends_on "linuxbrew/xorg/bdftopcf"

--- a/Formula/xorg-fonts.rb
+++ b/Formula/xorg-fonts.rb
@@ -7,6 +7,10 @@ class XorgFonts < Formula
   sha256   "3baf64afb29129ea9f74d5ae5a223b072d0911d96283f834e37d8f65d751c5d7"
   # tag "linuxbrew"
 
+  livecheck do
+    skip "Formula only installs other formulae"
+  end
+
   bottle :unneeded
 
   depends_on "linuxbrew/xorg/encodings"

--- a/Formula/xorg.rb
+++ b/Formula/xorg.rb
@@ -8,6 +8,10 @@ class Xorg < Formula
   revision 1
   # tag "linuxbrew"
 
+  livecheck do
+    skip "Formula only installs other formulae"
+  end
+
   bottle :unneeded
 
   option "with-docs", "Build documentation and specifications (where applicable)"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

This adds `livecheck` blocks to skip `xorg`, `xorg-apps`, and `xorg-fonts`, since they only install other formulae and they can't be checked like normal formulae. Let me know if you would prefer a different skip message and I'll update these.