### PR TITLE
Remove remaining root_urls from formulas

### DIFF
--- a/Formula/bdftopcf.rb
+++ b/Formula/bdftopcf.rb
@@ -8,7 +8,6 @@ class Bdftopcf < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "5053b8540a1a6a17e82d2636e8228fd0c2863f1d75a55c82c8c0bdd28ac1bf87" => :x86_64_linux
   end

--- a/Formula/glu.rb
+++ b/Formula/glu.rb
@@ -11,7 +11,6 @@ class Glu < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "41b97b80a25d2ccd426ffbde60021eee2743540ee532b10bb6d521af63ff7cb5" => :x86_64_linux
   end

--- a/Formula/iceauth.rb
+++ b/Formula/iceauth.rb
@@ -8,7 +8,6 @@ class Iceauth < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "9d70e587531b5ef404a1542d06aa7fd38975d970f98f8336cb161f28e06b3258" => :x86_64_linux
   end

--- a/Formula/libdmx.rb
+++ b/Formula/libdmx.rb
@@ -6,7 +6,6 @@ class Libdmx < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "25d5abde6a37a12ffd76955d4eaba16bf7136667631ba088bc61aff1362a4fa3" => :x86_64_linux
   end

--- a/Formula/libevdev.rb
+++ b/Formula/libevdev.rb
@@ -6,7 +6,6 @@ class Libevdev < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     rebuild 1
     sha256 "8ff50a765f65bb5d1fcd504ac98a53d99e90e04cec50979bb6292b14825ea56c" => :x86_64_linux

--- a/Formula/libfontenc.rb
+++ b/Formula/libfontenc.rb
@@ -6,7 +6,6 @@ class Libfontenc < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "1c05a169250850d29a8dd10a4ccb56aa085be780971ad7c2ad8a1eb80fa6875d" => :x86_64_linux
   end

--- a/Formula/libglvnd.rb
+++ b/Formula/libglvnd.rb
@@ -7,7 +7,6 @@ class Libglvnd < Formula
   head "https://gitlab.freedesktop.org/glvnd/libglvnd.git"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "0a23a0224a74e409d5ed4ed556a26a20f28db30afef4b8340feaa957a91e2ec3" => :x86_64_linux
   end

--- a/Formula/libgudev.rb
+++ b/Formula/libgudev.rb
@@ -10,7 +10,6 @@ class Libgudev < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "f11f69ae79e8d89a5d579e64c8ec196c3f5dd0b6bb8bef3435cd8b69db167240" => :x86_64_linux
   end

--- a/Formula/libomxil-bellagio.rb
+++ b/Formula/libomxil-bellagio.rb
@@ -6,7 +6,6 @@ class LibomxilBellagio < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     sha256 "8f405db484d10304e0d5db1d7096b5f1ad672910ddb6b5a36ad5ee0219a11a1b" => :x86_64_linux
   end
 

--- a/Formula/libpthread-stubs.rb
+++ b/Formula/libpthread-stubs.rb
@@ -6,7 +6,6 @@ class LibpthreadStubs < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "b5075aa908c76b2ff95b14c0ece59a99caa84875c5c889e6d12a1b7153cd79a8" => :x86_64_linux
   end

--- a/Formula/libsm.rb
+++ b/Formula/libsm.rb
@@ -6,7 +6,6 @@ class Libsm < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "c545076505335487a8e96a628c41fa57674135b321eee6aadb7fcf564d649fb8" => :x86_64_linux
   end

--- a/Formula/libva-internal.rb
+++ b/Formula/libva-internal.rb
@@ -10,7 +10,6 @@ class LibvaInternal < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "18fcda223fafca140f308c5e7131e9a89c16dee3a0311f7f71b2e325af5c7862" => :x86_64_linux
   end

--- a/Formula/libva.rb
+++ b/Formula/libva.rb
@@ -10,7 +10,6 @@ class Libva < Formula
   end
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "32da96f256bd627e69dee7a0bc1e572af08c0b9c6ba6a8c71ad178f8beb6bc40" => :x86_64_linux
   end

--- a/Formula/libxau.rb
+++ b/Formula/libxau.rb
@@ -6,7 +6,6 @@ class Libxau < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "bd260bed706b2492da210eaab8fcd2192baf3c24403267967a28e9ae35d6f518" => :x86_64_linux
   end

--- a/Formula/libxaw3d.rb
+++ b/Formula/libxaw3d.rb
@@ -6,7 +6,6 @@ class Libxaw3d < Formula
   sha256 "2dba993f04429ec3d7e99341e91bf46be265cc482df25963058c15f1901ec544"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "b16f1cb6c8c7a86c998e3a0b5b8d42827755a755411632dc005d82d2eb612d3f" => :x86_64_linux
   end

--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -7,7 +7,6 @@ class Libxcb < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "71e21416bda37d0b5468451eb73b65abf3edce3ced56f12c4da45412ce2c5f36" => :x86_64_linux
   end

--- a/Formula/libxfont.rb
+++ b/Formula/libxfont.rb
@@ -6,7 +6,6 @@ class Libxfont < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "1c35567f2f949d001eaa8391f2633d44d5f7173213506ede9d72606200a44aae" => :x86_64_linux
   end

--- a/Formula/libxfontcache.rb
+++ b/Formula/libxfontcache.rb
@@ -6,7 +6,6 @@ class Libxfontcache < Formula
   sha256 "fdba75307a0983d2566554e0e9effa7079551f1b7b46e8de642d067998619659"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "3b8897ea5bd5244076f029fe03c6bd60795e18c032a3c5aa739d053ed63eddc4" => :x86_64_linux
   end

--- a/Formula/libxinerama.rb
+++ b/Formula/libxinerama.rb
@@ -6,7 +6,6 @@ class Libxinerama < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "ddf87c09432fe14d066753d83aece10e0597b19afa7d334543b59adad4efc20c" => :x86_64_linux
   end

--- a/Formula/libxres.rb
+++ b/Formula/libxres.rb
@@ -6,7 +6,6 @@ class Libxres < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "cf3f1306d58e362dcc4340f059eac9971bab8fc67b4ce0a8c15cedd8b0fb4bd7" => :x86_64_linux
   end

--- a/Formula/libxscrnsaver.rb
+++ b/Formula/libxscrnsaver.rb
@@ -6,7 +6,6 @@ class Libxscrnsaver < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "201bfe6a40c71968795a354c8ea51703cff91483a3ec9bbc271e967f8b5e2205" => :x86_64_linux
   end

--- a/Formula/libxshmfence.rb
+++ b/Formula/libxshmfence.rb
@@ -6,7 +6,6 @@ class Libxshmfence < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "23008fee00e43a497d1344ac7d675ee6116137ba409fa1d4d4c05333fb6a6d78" => :x86_64_linux
   end

--- a/Formula/libxxf86misc.rb
+++ b/Formula/libxxf86misc.rb
@@ -6,7 +6,6 @@ class Libxxf86misc < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "58d5350b99200b7f6675fecc4e92252f45ae9c4488173dae86889976b1922c42" => :x86_64_linux
   end

--- a/Formula/umockdev.rb
+++ b/Formula/umockdev.rb
@@ -5,7 +5,6 @@ class Umockdev < Formula
   sha256 "ffb6134667f510a146b533076eb1a316392c7902a4ec593080de9fb53393e8bc"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "ef755d8926a10f616e2b5095bf6bf7f47421843846468d2ca736ddcdd767fe5d" => :x86_64_linux
   end

--- a/Formula/util-macros.rb
+++ b/Formula/util-macros.rb
@@ -7,7 +7,6 @@ class UtilMacros < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "02b0459adfed7cedc617f47c9e28f507169a1965643ff58a816ba8625d0feaa0" => :x86_64_linux
   end

--- a/Formula/wayland.rb
+++ b/Formula/wayland.rb
@@ -6,7 +6,6 @@ class Wayland < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     rebuild 1
     sha256 "d3bfcf08a75e5af6c9040577eb4a62e7cb9026446f1016166695bb1371a82e12" => :x86_64_linux

--- a/Formula/xbitmaps.rb
+++ b/Formula/xbitmaps.rb
@@ -5,7 +5,6 @@ class Xbitmaps < Formula
   sha256 "b9f0c71563125937776c8f1f25174ae9685314cbd130fb4c2efce811981e07ee"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "0bdbe7764069c18309ee18f7b8b9d5ad6b69e8ad49c7af376350f184dc7ecfac" => :x86_64_linux
   end

--- a/Formula/xcb-proto.rb
+++ b/Formula/xcb-proto.rb
@@ -6,7 +6,6 @@ class XcbProto < Formula
   revision 2
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "fa7cc6cc3a57e41ce388e0326969f91a4ccf7da19dea778652d4b25ec809ea60" => :x86_64_linux
   end

--- a/Formula/xcb-util-keysyms.rb
+++ b/Formula/xcb-util-keysyms.rb
@@ -5,7 +5,6 @@ class XcbUtilKeysyms < Formula
   sha256 "0ef8490ff1dede52b7de533158547f8b454b241aa3e4dcca369507f66f216dd9"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "154c7d7141aa13ada667a9cf683fa2e4b898de7a4c37a18e3463c3bb5c6f727b" => :x86_64_linux
   end

--- a/Formula/xcb-util-renderutil.rb
+++ b/Formula/xcb-util-renderutil.rb
@@ -5,7 +5,6 @@ class XcbUtilRenderutil < Formula
   sha256 "c6e97e48fb1286d6394dddb1c1732f00227c70bd1bedb7d1acabefdd340bea5b"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "e6452ef548b8135234cbea14e8105432c414eb4099db2483803456109d93398b" => :x86_64_linux
   end

--- a/Formula/xcursor-themes.rb
+++ b/Formula/xcursor-themes.rb
@@ -9,7 +9,6 @@ class XcursorThemes < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "aff195169736624a1f847c7689323a09d71e9ab9d491c8c88e449a78df6101dc" => :x86_64_linux
   end

--- a/Formula/xcursorgen.rb
+++ b/Formula/xcursorgen.rb
@@ -8,7 +8,6 @@ class Xcursorgen < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "8a65d22d2314fd076f0bcbb637a3bfce31b60a3ec14bd6b6cfd2173ea574e0c8" => :x86_64_linux
   end

--- a/Formula/xdriinfo.rb
+++ b/Formula/xdriinfo.rb
@@ -8,7 +8,6 @@ class Xdriinfo < Formula
   revision 1
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "d2a11d9cb644ccd419b865e5deabdc0e8250d101a2656311accd0233ba82084e" => :x86_64_linux
   end

--- a/Formula/xev.rb
+++ b/Formula/xev.rb
@@ -8,7 +8,6 @@ class Xev < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "53ce8fdaf7221888e6876a07192c7b12ae312cf6ae4820669796dff4c14a7cfc" => :x86_64_linux
   end

--- a/Formula/xhost.rb
+++ b/Formula/xhost.rb
@@ -8,7 +8,6 @@ class Xhost < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "4f0ad2aa69c22aa6c5292732eb99160554febe42cc3352140910b0adfb6e615b" => :x86_64_linux
   end

--- a/Formula/xkbcomp.rb
+++ b/Formula/xkbcomp.rb
@@ -8,7 +8,6 @@ class Xkbcomp < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     sha256 "3956c51a54082f8be79ddce4eeddcef9b9e98f15a75ad880fb767ad0a6dbf68f" => :x86_64_linux
   end
 

--- a/Formula/xkbutils.rb
+++ b/Formula/xkbutils.rb
@@ -7,7 +7,6 @@ class Xkbutils < Formula
   mirror "https://ftp.x.org/pub/individual/app/xkbutils-1.0.4.tar.bz2"
   sha256 "d2a18ab90275e8bca028773c44264d2266dab70853db4321bdbc18da75148130"
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "951a9f5e210d501b0d0b69764b0cbf01acc7a082c0a76ca27ef06e77f949b8e9" => :x86_64_linux
   end

--- a/Formula/xkill.rb
+++ b/Formula/xkill.rb
@@ -8,7 +8,6 @@ class Xkill < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "1d8111e12d4d90df8f9a32011ac8a0dcf8f272686f2a7029ce6f09095d3a0de5" => :x86_64_linux
   end

--- a/Formula/xlsatoms.rb
+++ b/Formula/xlsatoms.rb
@@ -8,7 +8,6 @@ class Xlsatoms < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "18c4544e73b69d0afd29698a0c7f5df76666d5c4750f9ea57142e6c9363771bd" => :x86_64_linux
   end

--- a/Formula/xlsclients.rb
+++ b/Formula/xlsclients.rb
@@ -8,7 +8,6 @@ class Xlsclients < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "f301335cfcf4353ad6580271b7645737abe3b971cbb0f4426582e3377edd8a8a" => :x86_64_linux
   end

--- a/Formula/xmessage.rb
+++ b/Formula/xmessage.rb
@@ -8,7 +8,6 @@ class Xmessage < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "241ed2043ecd1ada147c20b545fb643e335eb5e0aef1ede78a3ca6e705c4fdd1" => :x86_64_linux
   end

--- a/Formula/xmodmap.rb
+++ b/Formula/xmodmap.rb
@@ -8,7 +8,6 @@ class Xmodmap < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "e0c1fcabb2f971799f2002735df6bed6fc8bd79717a7a65cac29f5b6319861f0" => :x86_64_linux
   end

--- a/Formula/xorg-docs.rb
+++ b/Formula/xorg-docs.rb
@@ -6,7 +6,6 @@ class XorgDocs < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "e5240c5104e2585df365cf6a6873d6d1e208b01cffa2ff9654c251c65de61784" => :x86_64_linux
   end

--- a/Formula/xpr.rb
+++ b/Formula/xpr.rb
@@ -8,7 +8,6 @@ class Xpr < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "154ab66b8b502e0ef83220edfbda3c1e58b120aea540940064ad09ce0e276ae3" => :x86_64_linux
   end

--- a/Formula/xrdb.rb
+++ b/Formula/xrdb.rb
@@ -8,7 +8,6 @@ class Xrdb < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     sha256 "a4fdfc3af56a2d0ba90dc60458de4fe296dc296ec000214165203d41990dad4a" => :x86_64_linux
   end
 

--- a/Formula/xrefresh.rb
+++ b/Formula/xrefresh.rb
@@ -8,7 +8,6 @@ class Xrefresh < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "789bb485320ea97f938405701558d1547fcd5b8269e8e50040ab59031d71b3b5" => :x86_64_linux
   end

--- a/Formula/xset.rb
+++ b/Formula/xset.rb
@@ -6,7 +6,6 @@ class Xset < Formula
   mirror "https://ftp.x.org/pub/individual/app/xset-1.2.4.tar.bz2"
   sha256 "e4fd95280df52a88e9b0abc1fee11dcf0f34fc24041b9f45a247e52df941c957"
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "09a4180771bd7661f2f97fefe6150712049aa8c7b2745fd84d97decaffa1c407" => :x86_64_linux
   end

--- a/Formula/xsetroot.rb
+++ b/Formula/xsetroot.rb
@@ -8,7 +8,6 @@ class Xsetroot < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "8a2c03ef486e7dcfa3c6239a78f50cfc0346b58b3b8d0075e5adbfe314918ade" => :x86_64_linux
   end

--- a/Formula/xvinfo.rb
+++ b/Formula/xvinfo.rb
@@ -8,7 +8,6 @@ class Xvinfo < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "e21a8eb9d99bb15080de0cfa8490050a38b3e61204d4de7f8cfd6ce14b1b5609" => :x86_64_linux
   end

--- a/Formula/xwd.rb
+++ b/Formula/xwd.rb
@@ -8,7 +8,6 @@ class Xwd < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "e9359e31e67cf18bb3e2be287c77298f59d34ef597600513501a65097e3b0037" => :x86_64_linux
   end

--- a/Formula/xwud.rb
+++ b/Formula/xwud.rb
@@ -8,7 +8,6 @@ class Xwud < Formula
   # tag "linuxbrew"
 
   bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
     sha256 "ef73f96b2bed685ecdeba368742b3df67eb020d4f9ff2e84b77d0aa4acf3a18e" => :x86_64_linux
   end


### PR DESCRIPTION
Having a `root_url` prevents `HOMEBREW_BOTTLE_DOMAIN` from taking effect.

The other two-thirds of formulas don't have `root_url` and work as I'd expect.

Similar to Homebrew/linuxbrew-core#14600.

# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?