### PR TITLE
publish-commit-bottles: set tap flag

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -35,7 +35,7 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
           HOMEBREW_BINTRAY_USER: linuxbrewtestbot
           HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}
-        run: brew pr-pull --bintray-org=linuxbrew --keep-old --debug ${{github.event.inputs.args}} ${{github.event.inputs.pull_request}}
+        run: brew pr-pull --tap=linuxbrew/xorg --bintray-org=linuxbrew --keep-old --debug ${{github.event.inputs.args}} ${{github.event.inputs.pull_request}}
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master


### PR DESCRIPTION
# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?

