### PR TITLE
Update/add livecheck blocks

### DIFF
--- a/Formula/intel-media-driver.rb
+++ b/Formula/intel-media-driver.rb
@@ -5,8 +5,9 @@ class IntelMediaDriver < Formula
   sha256 "a03bd75eefe9cb0245e3aab2723b3fef555d9f180a180b2c29d7b12d483d9ec2"
 
   livecheck do
-    url "https://github.com/intel/media-driver/releases"
-    regex(%r{latest.*?href="/intel/media-driver/archive/intel-media-?([a-z0-9.]+)\.t}mi)
+    url :stable
+    strategy :github_latest
+    regex(%r{href=.*?/tag/intel-media[._-]v?([^"' >]+)["' >]}i)
   end
 
   bottle do

--- a/Formula/libgudev.rb
+++ b/Formula/libgudev.rb
@@ -6,7 +6,7 @@ class Libgudev < Formula
 
   livecheck do
     url :stable
-    regex(/libgudev[._-]v?(\d+(?:\.?\d+)+)\.t/i)
+    regex(/libgudev[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
   bottle do

--- a/Formula/libva-intel-driver.rb
+++ b/Formula/libva-intel-driver.rb
@@ -6,8 +6,8 @@ class LibvaIntelDriver < Formula
   revision 2
 
   livecheck do
-    url "https://github.com/intel/intel-vaapi-driver/releases"
-    regex(%r{latest.*?href="/intel/intel-vaapi-driver/tree/v?([a-z0-9.]+)}mi)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libva-internal.rb
+++ b/Formula/libva-internal.rb
@@ -6,8 +6,8 @@ class LibvaInternal < Formula
   revision 3
 
   livecheck do
-    url "https://github.com/intel/libva/releases"
-    regex(%r{Latest.*?href="/intel/libva/tree/v?([a-z0-9.]+)}im)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libva-utils.rb
+++ b/Formula/libva-utils.rb
@@ -5,6 +5,11 @@ class LibvaUtils < Formula
   sha256 "2249b5d08bffc3862bbdcc9a6a4827afd504330b8d101564d39fe1a1e7adc426"
   revision 2
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation

--- a/Formula/libva.rb
+++ b/Formula/libva.rb
@@ -6,8 +6,8 @@ class Libva < Formula
   revision 3
 
   livecheck do
-    url "https://github.com/intel/libva/releases"
-    regex(%r{latest.*?href="/intel/libva/tree/v?([a-z0-9.]+)}mi)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libvdpau-va-gl.rb
+++ b/Formula/libvdpau-va-gl.rb
@@ -6,8 +6,8 @@ class LibvdpauVaGl < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/i-rinat/libvdpau-va-gl/releases"
-    regex(%r{latest.*?href="/i-rinat/libvdpau-va-gl/tree/v?([a-z0-9.]+)}mi)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libwacom.rb
+++ b/Formula/libwacom.rb
@@ -5,8 +5,9 @@ class Libwacom < Formula
   sha256 "c204cfdee2159d124a4f5ecc8970bbd72f9adf5ad7fd94b66798f93db1f863c3"
 
   livecheck do
-    url "https://github.com/linuxwacom/libwacom/releases"
-    regex(/libwacom-([0-9.]+)\.tar.bz2/i)
+    url :stable
+    strategy :github_latest
+    regex(%r{href=.*?/tag/(?:libwacom[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?

---

I'm working on a Homebrew/brew PR and I was testing the `Xorg` strategy, so I decided to run it against `homebrew-xorg` to see how things are holding up over here. Unfortunately, a few of the existing checks that don't use `Xorg` have broken since I last worked on `livecheck` blocks in this repository.

This PR:

* Updates existing `livecheck` blocks that don't work correctly
* Updates an existing `regex` (in `libgudev`)  to bring it in line with similar regexes in homebrew/core
* Adds a `livecheck` block for `libva-utils`, as it was reporting a version from the `Git` tags that was newer than the "latest" release on GitHub

I'm handling all these changes in one PR, primarily to make this easy on myself, but let me know if I need to split this into separate PRs. The details for each of these changes can be found below.

### `intel-media-driver`

**Before**: `Error: intel-media-driver: Unable to get versions`
**After**: `intel-media-driver : 19.4.0r ==> 20.3.0`

The existing livecheck block was trying to check the GitHub releases page (which we explicitly avoid doing, since it's paginated and the latest release may not be present) but the URL was being preprocessed into the Git repository URL since `strategy :page_match` wasn't present in the `livecheck` block. The existing `regex` was intended for the context of the releases page, so it fails when checking the Git tags.

Besides that, when checking the Git tags, livecheck will report `600.0132` as the newest version, due to a `intel-media-600.0132` tag. Instead of trying to manually omit the `600.x` tags and hope for the best, we can avoid this situation entirely by checking the "latest" release on GitHub. The `GithubLatest` strategy does what the existing `livecheck` block was intending to do but in a more appropriate (and reliable) manner.

Normally you can just use `url :stable` along with `stategy :github_latest` and call it a day (using the strategy's default regex to match the tag from an `href` attribute). However, `intel-media-driver` tags are like `intel-media-1.2.3`, so it was necessary to add a regex that accounts for the `intel-media-` prefix.

### `libgudev`

**Before**: `libgudev : 233 ==> 234`
**After**: `libgudev : 233 ==> 234`

There isn't any functional difference in the regex change here and I've merely refactored the regex to follow a common pattern that we use in `homebrew/core` formulae. That is to say, the standard regex for matching version text like `1.2.3`/`v1.2.3` is `v?(\d+(?:\.\d+)+)` and simply modifying the repeating group to optionally repeat (`v?(\d+(?:\.\d+)*)`) allows it to match versions like `234` here.

It's worth noting that this check will continue to intermittently fail, since the `Gnome` strategy can involve an HTTPS to HTTP redirection depending on the mirror you're pointed to. `open-uri` forbids HTTPS to HTTP redirections and you'll receive an error message like `Error: libgudev: redirection forbidden: https://download.gnome.org/sources/libgudev/cache.json -> http://ftp.cse.buffalo.edu/pub/Gnome/sources/libgudev/cache.json`.

I'm working on addressing this through internal changes to `brew livecheck` but I'm still troubleshooting an issue with the new approach, so it hasn't landed yet. Once I work out the remaining bug, this error will automatically go away without needing to update `Gnome` or `libgudev`.

### `libva-intel-driver`

**Before**: `Error: libva-intel-driver: Unable to get versions`
**After**: `libva-intel-driver : 2.4.0 ==> 2.4.1`

The existing `livecheck` block was failing for the same reason as `intel-media-driver` (URL preprocessed into Git URL but regex is intended for `PageMatch`). Using `GithubLatest` is appropriate here as well and we don't need to use a `regex` since the strategy regex already works with tags like `1.2.3`/`v1.2.3`.

### `libva-internal`

**Before**: `Error: libva-internal: Unable to get versions`
**After**: `libva-internal : 2.6.1 ==> 2.10.0`

Same situation as `libva-intel-driver`.

### `libva-utils`

**Before**: `libva-utils : 2.6.0 ==> 2.10.0`
**After**: `libva-utils : 2.6.0 ==> 2.9.1`

`libva-utils` didn't have a `livecheck` block and livecheck was checking the Git tags from GitHub by default. This seems to work fine on the surface but the newest Git tag, `2.10.0` isn't marked as the "latest" release on GitHub. In this situation, it's necessary to check the "latest" release instead. After adding a simple `livecheck` block that uses the `GithubLatest` strategy, we get the correct latest version, `2.9.1`.

### `libva`

**Before**: `Error: libva: Unable to get versions`
**After**: `libva : 2.6.1 ==> 2.10.0`

Same situation as `libva-intel-driver`.

### `libvdpau-va-gl`

**Before**: `Error: libvdpau-va-gl: Unable to get versions`
**After**: `libvdpau-va-gl : 0.4.2 ==> 0.4.2`

Same situation as `libva-intel-driver`.

### `libwacom`

**Before**: `Error: libwacom: Unable to get versions`
**After**: `libwacom : 1.2 ==> 1.7`

The situation for `libwacom` was similar to `libva-intel-driver`, except the regex in the existing `livecheck` block was matching a release archive instead of the tag name. Using `GithubLatest` is fine here as well.

## Closing

It's probably worth mentioning that we generally only use the `GithubLatest` strategy at the moment when it's necessary or would be clearly beneficial. We have thousands of formulae in homebrew/core that come from GitHub but checking the GitHub website for all of these could potentially lead to us hitting the rate limit when running `brew livecheck --tap homebrew/core`. There doesn't seem to be a rate limit when checking Git tags, so we still use that by default, until/unless it becomes a problem for a given formula. Just something to keep in mind, so you don't go wild applying the `GithubLatest` strategy (if the urge takes you after seeing these changes), ahah.

Let me know if you think any of this needs to change in any way. Otherwise, enjoy having these checks work properly again.