### PR TITLE
formulae*: remove sha255 for rebuild

### DIFF
--- a/Formula/intel-media-driver.rb
+++ b/Formula/intel-media-driver.rb
@@ -13,7 +13,6 @@ class IntelMediaDriver < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "27e721bb9b49179017e50998da0847a72658452870964963aab109e2c58fd2d7" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/Formula/libva-intel-driver.rb
+++ b/Formula/libva-intel-driver.rb
@@ -12,7 +12,6 @@ class LibvaIntelDriver < Formula
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
-    sha256 "9f7b8fd12c0bcbda395f5d55ee980075ad309d5961b0bf4c831478715d5fb757" => :x86_64_linux
   end
 
   depends_on "libva" => :build

--- a/Formula/libva-utils.rb
+++ b/Formula/libva-utils.rb
@@ -13,7 +13,6 @@ class LibvaUtils < Formula
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-xorg"
     cellar :any_skip_relocation
-    sha256 "38b7426a515756b68c92b650507de1ece3a6e4c00a68b8904fbeb56e1d4964ac" => :x86_64_linux
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
# Contributing to homebrew-xorg:

_You can erase any parts of this template not applicable to your Pull Request._

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-xorg/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?

