### PR TITLE
intel-media-driver: update livecheck regex

### DIFF
--- a/Formula/intel-media-driver.rb
+++ b/Formula/intel-media-driver.rb
@@ -8,7 +8,7 @@ class IntelMediaDriver < Formula
   livecheck do
     url :stable
     strategy :github_latest
-    regex(%r{href=.*?/tag/intel-media[._-]v?([^"' >]+)["' >]}i)
+    regex(%r{href=.*?/tag/intel-media[._-]v?([^"' >&]+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
Update livecheck regex

Current behavior:

```
$ brew livecheck intel-media-driver
intel-media-driver : 19.4.0r ==> 21.2.3&quot;,&quot;user_id&quot;:null}}
```

Updated behavior:

```
$ brew livecheck intel-media-driver
intel-media-driver : 19.4.0r ==> 21.2.3
```
