### PR TITLE
No bottle unneeded

### DIFF
--- a/Formula/xorg-apps.rb
+++ b/Formula/xorg-apps.rb
@@ -12,8 +12,6 @@ class XorgApps < Formula
     skip "Formula only installs other formulae"
   end
 
-  bottle :unneeded
-
   depends_on "linuxbrew/xorg/bdftopcf"
   depends_on "linuxbrew/xorg/iceauth"
   depends_on "linuxbrew/xorg/luit"

--- a/Formula/xorg-fonts.rb
+++ b/Formula/xorg-fonts.rb
@@ -12,8 +12,6 @@ class XorgFonts < Formula
     skip "Formula only installs other formulae"
   end
 
-  bottle :unneeded
-
   depends_on "font-util" => :build
   depends_on "linuxbrew/xorg/encodings"
   depends_on "linuxbrew/xorg/font-adobe-100dpi"


### PR DESCRIPTION
Removing "bottle :unneeded" from xorg-fonts and xorg-apps.